### PR TITLE
Qt5/Qt6 dual-compatibility for QGIS 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+    push:
+        branches: ["**"]
+    pull_request:
+        branches: [main]
+
+jobs:
+    pre-commit:
+        name: pre-commit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - uses: pre-commit/action@v3.0.1
+
+    bandit:
+        name: Bandit security scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - name: Install Bandit
+              run: pip install bandit
+            - name: Run Bandit (matches plugins.qgis.org security scan)
+              run: bandit -r nasa_earthdata
+
+    pyqt6-smoke:
+        name: PyQt6 import smoke
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Qt6 runtime libs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+            - name: Install PyQt6 and pytest
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install PyQt6 pytest
+            - name: Run import smoke tests
+              run: pytest tests -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,10 @@ repos:
       rev: 0.9.1
       hooks:
           - id: nbstripout
+
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.9.4
+      hooks:
+          - id: bandit
+            args: ["-r", "nasa_earthdata"]
+            pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A QGIS plugin for searching, visualizing, and downloading NASA Earthdata product
 
 ### Prerequisites
 
-1. **QGIS 3.28 or higher**
+1. **QGIS 3.28 or higher** (compatible with QGIS 4.0 / Qt6 as well)
 2. **NASA Earthdata Account**: Sign up at [urs.earthdata.nasa.gov](https://urs.earthdata.nasa.gov/)
 
 ### Install QGIS and Google Earth Engine

--- a/nasa_earthdata/core/net.py
+++ b/nasa_earthdata/core/net.py
@@ -1,0 +1,88 @@
+"""HTTPS-only network helpers for plugin downloads.
+
+Centralizes the security guard so any future tightening (header policy,
+redirect handling, etc.) is applied everywhere consistently. The helpers
+reject non-https URLs both on the initial request and on any redirect
+target, so an https URL that 301s to http is still refused.
+"""
+
+import urllib.request
+from typing import Callable, Optional
+
+
+def require_https(url: str) -> None:
+    """Reject any URL that is not ``https://``.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValueError: If ``url`` does not start with ``https://``.
+    """
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"Refusing non-https URL: {url!r}")
+
+
+class _HttpsOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """HTTPRedirectHandler that refuses any non-https redirect target."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        """Validate ``newurl`` is https before following the redirect."""
+        require_https(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _build_opener() -> urllib.request.OpenerDirector:
+    """Build a urllib opener that enforces https on redirects."""
+    return urllib.request.build_opener(_HttpsOnlyRedirectHandler())
+
+
+def https_only_urlopen(url: str, timeout: float = 30):
+    """``urlopen`` wrapper that rejects non-https URLs and redirects.
+
+    Args:
+        url: The URL to open. Must use the ``https`` scheme.
+        timeout: Socket timeout in seconds.
+
+    Returns:
+        A response object compatible with ``urllib.request.urlopen``.
+    """
+    require_https(url)
+    opener = _build_opener()
+    return opener.open(url, timeout=timeout)  # nosec B310 - https enforced
+
+
+def https_only_urlretrieve(
+    url: str,
+    filename: str,
+    reporthook: Optional[Callable[[int, int, int], None]] = None,
+    timeout: float = 60,
+    chunk_size: int = 64 * 1024,
+) -> None:
+    """``urlretrieve`` replacement that enforces https everywhere.
+
+    Streams the response to ``filename`` in chunks. ``reporthook`` is
+    invoked with ``(block_num, block_size, total_size)`` like the stdlib
+    callback so existing progress UIs keep working.
+
+    Args:
+        url: The URL to download. Must use the ``https`` scheme.
+        filename: Destination path on disk.
+        reporthook: Optional progress callback.
+        timeout: Socket timeout in seconds.
+        chunk_size: Number of bytes to read per loop iteration.
+    """
+    require_https(url)
+    opener = _build_opener()
+    with opener.open(url, timeout=timeout) as resp:  # nosec B310 - https enforced
+        total_size = int(resp.headers.get("Content-Length") or 0)
+        block_num = 0
+        with open(filename, "wb") as out:
+            while True:
+                chunk = resp.read(chunk_size)
+                if not chunk:
+                    break
+                out.write(chunk)
+                block_num += 1
+                if reporthook is not None:
+                    reporthook(block_num, len(chunk), total_size)

--- a/nasa_earthdata/core/python_manager.py
+++ b/nasa_earthdata/core/python_manager.py
@@ -11,7 +11,7 @@ Source: https://github.com/astral-sh/python-build-standalone
 import os
 import sys
 import platform
-import subprocess
+import subprocess  # nosec B404 - only invoked with hard-coded internal commands
 import tarfile
 import zipfile
 import tempfile
@@ -38,12 +38,12 @@ PYTHON_VERSIONS = {
 }
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "NASA Earthdata", level=level)
 
@@ -214,7 +214,7 @@ def download_python_standalone(progress_callback=None, cancel_check=None):
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -255,7 +255,7 @@ def download_python_standalone(progress_callback=None, cancel_check=None):
         if success:
             if progress_callback:
                 progress_callback(100, f"Python {python_version} installed")
-            _log("Python standalone installed successfully", Qgis.Success)
+            _log("Python standalone installed successfully", Qgis.MessageLevel.Success)
             return True, f"Python {python_version} installed successfully"
         else:
             return False, f"Verification failed: {verify_msg}"
@@ -264,7 +264,7 @@ def download_python_standalone(progress_callback=None, cancel_check=None):
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"Installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
 
         if sys.platform == "win32":
             error_lower = str(e).lower()
@@ -322,7 +322,7 @@ def verify_standalone_python():
             startupinfo.wShowWindow = subprocess.SW_HIDE
             kwargs["startupinfo"] = startupinfo
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - internal command list, shell=False
             [python_path, "-c", "import sys; print(sys.version)"],
             capture_output=True,
             text=True,
@@ -336,14 +336,20 @@ def verify_standalone_python():
             if not version_output.startswith(
                 f"{sys.version_info.major}.{sys.version_info.minor}"
             ):
-                _log(f"Python version mismatch: got {version_output}", Qgis.Warning)
+                _log(
+                    f"Python version mismatch: got {version_output}",
+                    Qgis.MessageLevel.Warning,
+                )
                 return False, f"Version mismatch: {version_output}"
 
-            _log(f"Verified Python standalone: {version_output}", Qgis.Success)
+            _log(
+                f"Verified Python standalone: {version_output}",
+                Qgis.MessageLevel.Success,
+            )
             return True, f"Python {version_output} verified"
         else:
             error = result.stderr or "Unknown error"
-            _log(f"Python verification failed: {error}", Qgis.Warning)
+            _log(f"Python verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -363,9 +369,9 @@ def remove_standalone_python():
 
     try:
         shutil.rmtree(STANDALONE_DIR)
-        _log("Removed standalone Python installation", Qgis.Success)
+        _log("Removed standalone Python installation", Qgis.MessageLevel.Success)
         return True, "Standalone Python removed"
     except Exception as e:
         error_msg = f"Failed to remove: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/nasa_earthdata/core/uv_manager.py
+++ b/nasa_earthdata/core/uv_manager.py
@@ -11,7 +11,7 @@ import os
 import sys
 import platform
 import stat
-import subprocess
+import subprocess  # nosec B404 - only invoked with hard-coded internal commands
 import tarfile
 import zipfile
 import tempfile
@@ -29,12 +29,12 @@ UV_DIR = os.path.join(CACHE_DIR, "uv")
 UV_VERSION = "0.10.6"
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "NASA Earthdata", level=level)
 
@@ -139,7 +139,7 @@ def download_uv(progress_callback=None, cancel_check=None):
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -210,7 +210,7 @@ def download_uv(progress_callback=None, cancel_check=None):
         if success:
             if progress_callback:
                 progress_callback(100, f"uv {UV_VERSION} installed")
-            _log("uv installed successfully", Qgis.Success)
+            _log("uv installed successfully", Qgis.MessageLevel.Success)
             return True, f"uv {UV_VERSION} installed successfully"
         else:
             return False, f"Verification failed: {verify_msg}"
@@ -219,7 +219,7 @@ def download_uv(progress_callback=None, cancel_check=None):
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"uv installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
         return False, error_msg
     finally:
         if os.path.exists(temp_path):
@@ -265,7 +265,7 @@ def verify_uv():
         if sys.platform == "win32":
             kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - internal command list, shell=False
             [uv_path, "--version"],
             capture_output=True,
             text=True,
@@ -276,11 +276,11 @@ def verify_uv():
 
         if result.returncode == 0:
             version_output = result.stdout.strip()
-            _log(f"Verified uv: {version_output}", Qgis.Success)
+            _log(f"Verified uv: {version_output}", Qgis.MessageLevel.Success)
             return True, version_output
         else:
             error = result.stderr or "Unknown error"
-            _log(f"uv verification failed: {error}", Qgis.Warning)
+            _log(f"uv verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -300,9 +300,9 @@ def remove_uv():
 
     try:
         shutil.rmtree(UV_DIR)
-        _log("Removed uv installation", Qgis.Success)
+        _log("Removed uv installation", Qgis.MessageLevel.Success)
         return True, "uv removed"
     except Exception as e:
         error_msg = f"Failed to remove uv: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -11,7 +11,7 @@ import importlib.metadata
 import os
 import platform
 import shutil
-import subprocess
+import subprocess  # nosec B404 - only invoked with hard-coded internal commands
 import sys
 import time
 from typing import Tuple, Optional, Callable, List
@@ -28,12 +28,12 @@ REQUIRED_PACKAGES = [
 ]
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "NASA Earthdata", level=level)
 
@@ -272,7 +272,7 @@ def _get_system_python():
     if python_path and os.path.isfile(python_path):
         _log(
             f"Standalone Python unavailable, using system Python: {python_path}",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return python_path
 
@@ -298,7 +298,10 @@ def _cleanup_partial_venv(venv_dir):
             shutil.rmtree(venv_dir, ignore_errors=True)
             _log(f"Cleaned up partial venv: {venv_dir}")
         except Exception:
-            _log(f"Could not clean up partial venv: {venv_dir}", Qgis.Warning)
+            _log(
+                f"Could not clean up partial venv: {venv_dir}",
+                Qgis.MessageLevel.Warning,
+            )
 
 
 def create_venv(venv_dir=None, progress_callback=None):
@@ -342,7 +345,7 @@ def create_venv(venv_dir=None, progress_callback=None):
         env = _get_clean_env_for_venv()
         kwargs = _get_subprocess_kwargs()
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - internal command list, shell=False
             cmd,
             capture_output=True,
             text=True,
@@ -352,7 +355,7 @@ def create_venv(venv_dir=None, progress_callback=None):
         )
 
         if result.returncode == 0:
-            _log("Virtual environment created successfully", Qgis.Success)
+            _log("Virtual environment created successfully", Qgis.MessageLevel.Success)
 
             # When using stdlib venv, ensure pip is available
             if not use_uv:
@@ -367,7 +370,7 @@ def create_venv(venv_dir=None, progress_callback=None):
                         "--upgrade",
                     ]
                     try:
-                        ensurepip_result = subprocess.run(
+                        ensurepip_result = subprocess.run(  # nosec B603 - internal command list, shell=False
                             ensurepip_cmd,
                             capture_output=True,
                             text=True,
@@ -376,14 +379,20 @@ def create_venv(venv_dir=None, progress_callback=None):
                             **kwargs,
                         )
                         if ensurepip_result.returncode == 0:
-                            _log("pip bootstrapped via ensurepip", Qgis.Success)
+                            _log(
+                                "pip bootstrapped via ensurepip",
+                                Qgis.MessageLevel.Success,
+                            )
                         else:
                             err = ensurepip_result.stderr or ensurepip_result.stdout
-                            _log(f"ensurepip failed: {err[:200]}", Qgis.Warning)
+                            _log(
+                                f"ensurepip failed: {err[:200]}",
+                                Qgis.MessageLevel.Warning,
+                            )
                             _cleanup_partial_venv(venv_dir)
                             return False, f"Failed to bootstrap pip: {err[:200]}"
                     except Exception as e:
-                        _log(f"ensurepip exception: {e}", Qgis.Warning)
+                        _log(f"ensurepip exception: {e}", Qgis.MessageLevel.Warning)
                         _cleanup_partial_venv(venv_dir)
                         return False, f"Failed to bootstrap pip: {str(e)[:200]}"
 
@@ -394,19 +403,21 @@ def create_venv(venv_dir=None, progress_callback=None):
             error_msg = (
                 result.stderr or result.stdout or f"Return code {result.returncode}"
             )
-            _log(f"Failed to create venv: {error_msg}", Qgis.Critical)
+            _log(f"Failed to create venv: {error_msg}", Qgis.MessageLevel.Critical)
             _cleanup_partial_venv(venv_dir)
             return False, f"Failed to create venv: {error_msg[:200]}"
 
     except subprocess.TimeoutExpired:
-        _log("Virtual environment creation timed out", Qgis.Critical)
+        _log("Virtual environment creation timed out", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
-        _log(f"Python executable not found: {system_python}", Qgis.Critical)
+        _log(
+            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+        )
         return False, f"Python not found: {system_python}"
     except Exception as e:
-        _log(f"Exception during venv creation: {str(e)}", Qgis.Critical)
+        _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, f"Error: {str(e)[:200]}"
 
@@ -543,7 +554,7 @@ def install_dependencies(venv_dir=None, progress_callback=None, cancel_check=Non
     if not success:
         return False, error_msg
 
-    _log(f"Installed {total} package(s)", Qgis.Success)
+    _log(f"Installed {total} package(s)", Qgis.MessageLevel.Success)
 
     if progress_callback:
         progress_callback(90, "All packages installed")
@@ -571,7 +582,7 @@ def _run_install_subprocess(
         A tuple of (returncode: int, stdout: str, stderr: str).
             returncode is -1 if cancelled, -2 if timed out.
     """
-    proc = subprocess.Popen(
+    proc = subprocess.Popen(  # nosec B603 - internal command list, shell=False
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -681,7 +692,7 @@ def _run_install(
             _log(
                 f"SSL error installing dependencies via {installer}, "
                 f"retrying with trusted hosts",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             retry_cmd = cmd + ssl_flags
             returncode, stdout, retry_stderr = _run_install_subprocess(
@@ -703,7 +714,7 @@ def _run_install(
             _log(
                 f"Network error installing dependencies via {installer}, "
                 f"retrying in 5s...",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             time.sleep(5)
             returncode, stdout, retry_stderr = _run_install_subprocess(
@@ -814,7 +825,7 @@ def verify_venv(venv_dir=None, progress_callback=None):
         cmd = [python_path, "-c", verify_code]
 
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 - internal command list, shell=False
                 cmd,
                 capture_output=True,
                 text=True,
@@ -829,23 +840,25 @@ def verify_venv(venv_dir=None, progress_callback=None):
                 )
                 _log(
                     f"Package {package_name} verification failed: {error_detail}",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
                 return False, (
                     f"Package {package_name} is broken: {error_detail[:200]}"
                 )
 
         except subprocess.TimeoutExpired:
-            _log(f"Verification of {package_name} timed out", Qgis.Warning)
+            _log(f"Verification of {package_name} timed out", Qgis.MessageLevel.Warning)
             return False, f"Verification of {package_name} timed out"
         except Exception as e:
-            _log(f"Failed to verify {package_name}: {str(e)}", Qgis.Warning)
+            _log(
+                f"Failed to verify {package_name}: {str(e)}", Qgis.MessageLevel.Warning
+            )
             return False, f"Verification error: {package_name}"
 
     if progress_callback:
         progress_callback(100, "Verification complete")
 
-    _log("Virtual environment verified successfully", Qgis.Success)
+    _log("Virtual environment verified successfully", Qgis.MessageLevel.Success)
     return True, "Virtual environment ready"
 
 
@@ -887,7 +900,7 @@ def _ensure_proj_data():
             _set_proj_data(proj_dir)
             return
     except Exception:
-        pass
+        pass  # nosec B110 - fall through to next PROJ-data lookup strategy
 
     # Strategy 2: sys.prefix/share/proj (conda / pixi / OSGeo4W)
     candidate = os.path.join(sys.prefix, "share", "proj")
@@ -906,7 +919,7 @@ def _ensure_proj_data():
                     _set_proj_data(candidate)
                     return
     except Exception:
-        pass
+        pass  # nosec B110 - fall through to next PROJ-data lookup strategy
 
     # Strategy 4: Search common system locations
     for candidate in (
@@ -917,7 +930,7 @@ def _ensure_proj_data():
             _set_proj_data(candidate)
             return
 
-    _log("Could not find PROJ data directory", Qgis.Warning)
+    _log("Could not find PROJ data directory", Qgis.MessageLevel.Warning)
 
 
 def ensure_venv_packages_available():
@@ -933,13 +946,13 @@ def ensure_venv_packages_available():
         python_path = get_venv_python_path()
         _log(
             f"Venv does not exist: expected Python at {python_path}",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return False
 
     site_packages = get_venv_site_packages()
     if site_packages is None:
-        _log(f"Venv site-packages not found in: {VENV_DIR}", Qgis.Warning)
+        _log(f"Venv site-packages not found in: {VENV_DIR}", Qgis.MessageLevel.Warning)
         return False
 
     if site_packages not in sys.path:
@@ -1072,7 +1085,7 @@ def create_venv_and_install(progress_callback=None, cancel_check=None):
             if fallback and os.path.isfile(fallback):
                 _log(
                     f"Standalone download failed, using system Python: {fallback}",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
             else:
                 return False, f"Failed to download Python: {msg}"
@@ -1101,7 +1114,7 @@ def create_venv_and_install(progress_callback=None, cancel_check=None):
             # Non-fatal: fall back to pip for venv creation and installation
             _log(
                 f"uv download failed ({msg}), will use pip instead",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
         else:
             _log("uv package installer ready")
@@ -1167,7 +1180,10 @@ def create_venv_and_install(progress_callback=None, cancel_check=None):
     if progress_callback:
         progress_callback(100, f"All dependencies installed in {elapsed_str}")
 
-    _log(f"All dependencies installed and verified in {elapsed_str}", Qgis.Success)
+    _log(
+        f"All dependencies installed and verified in {elapsed_str}",
+        Qgis.MessageLevel.Success,
+    )
     return True, f"All dependencies installed successfully in {elapsed_str}"
 
 
@@ -1202,9 +1218,9 @@ def cleanup_old_venv_directories():
                     except Exception as e:
                         _log(
                             f"Failed to remove old venv {old_path}: {e}",
-                            Qgis.Warning,
+                            Qgis.MessageLevel.Warning,
                         )
     except Exception as e:
-        _log(f"Error scanning for old venvs: {e}", Qgis.Warning)
+        _log(f"Error scanning for old venvs: {e}", Qgis.MessageLevel.Warning)
 
     return removed

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -54,6 +54,13 @@ NASA_DATA_URL = (
     "https://github.com/opengeos/NASA-Earth-Data/raw/main/nasa_earth_data.tsv"
 )
 
+
+def _require_https(url: str) -> None:
+    """Reject any URL that is not https:// before passing it to urllib."""
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"Refusing non-https URL: {url!r}")
+
+
 # Cache settings
 CACHE_DIR = Path(tempfile.gettempdir()) / "nasa_earthdata_cache"
 CATALOG_CACHE_FILE = CACHE_DIR / "nasa_earth_data.tsv"
@@ -66,8 +73,8 @@ class NumericTableWidgetItem(QTableWidgetItem):
     def __lt__(self, other):
         """Compare items using numeric data stored in UserRole."""
         try:
-            self_data = self.data(Qt.UserRole)
-            other_data = other.data(Qt.UserRole)
+            self_data = self.data(Qt.ItemDataRole.UserRole)
+            other_data = other.data(Qt.ItemDataRole.UserRole)
             # Handle None values
             if self_data is None:
                 return True
@@ -170,7 +177,10 @@ class CatalogLoadWorker(QThread):
                     rows = list(reader)
             else:
                 self.progress.emit("Downloading NASA Earthdata catalog...")
-                with urllib.request.urlopen(NASA_DATA_URL, timeout=30) as resp:
+                _require_https(NASA_DATA_URL)
+                with urllib.request.urlopen(
+                    NASA_DATA_URL, timeout=30
+                ) as resp:  # nosec B310 - https-only enforced above
                     text = resp.read().decode("utf-8")
                 # Save raw TSV to cache
                 with open(CATALOG_CACHE_FILE, "w", encoding="utf-8") as f:
@@ -375,7 +385,7 @@ class COGDisplayWorker(QThread):
                     self.progress.emit(f"Authenticated via {strategy}")
                     return True
             except Exception:
-                continue
+                continue  # nosec B112 - try the next auth strategy
 
         # Try credentials from Settings input boxes
         if self.username and self.password:
@@ -387,7 +397,7 @@ class COGDisplayWorker(QThread):
                     self.progress.emit("Authenticated via settings input")
                     return True
             except Exception:
-                pass
+                pass  # nosec B110 - auth failure handled by returning False below
 
         return False
 
@@ -542,7 +552,9 @@ class EarthdataDockWidget(QDockWidget):
         self.iface = iface
         self.settings = QSettings()
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         # Set minimum width but allow resizing
         self.setMinimumWidth(300)
@@ -569,8 +581,8 @@ class EarthdataDockWidget(QDockWidget):
         # Create scroll area for the content
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
 
         # Main widget inside scroll area
         main_widget = QWidget()
@@ -602,7 +614,9 @@ class EarthdataDockWidget(QDockWidget):
         # Search section
         search_group = QGroupBox("Search Parameters")
         search_layout = QFormLayout(search_group)
-        search_layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        search_layout.setFieldGrowthPolicy(
+            QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow
+        )
 
         # Keyword filter
         self.keyword_input = QLineEdit()
@@ -615,7 +629,9 @@ class EarthdataDockWidget(QDockWidget):
         self.dataset_combo.setMaxVisibleItems(20)
         self.dataset_combo.currentTextChanged.connect(self._on_dataset_changed)
         # Use AdjustToContents so dropdown shows full text
-        self.dataset_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.dataset_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToContents
+        )
         self.dataset_combo.setMinimumContentsLength(20)
         search_layout.addRow("Dataset:", self.dataset_combo)
 
@@ -676,7 +692,9 @@ class EarthdataDockWidget(QDockWidget):
         # Advanced options container widget (hidden by default)
         self.advanced_widget = QWidget()
         advanced_layout = QFormLayout(self.advanced_widget)
-        advanced_layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        advanced_layout.setFieldGrowthPolicy(
+            QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow
+        )
         advanced_layout.setContentsMargins(10, 5, 0, 5)
 
         # Cloud cover range
@@ -793,14 +811,22 @@ class EarthdataDockWidget(QDockWidget):
         self.results_table.setHorizontalHeaderLabels(["ID", "Date", "Size"])
         # ID column stretches to fill space, Date and Size are fixed width
         self.results_table.horizontalHeader().setSectionResizeMode(
-            0, QHeaderView.Stretch
+            0, QHeaderView.ResizeMode.Stretch
         )
-        self.results_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Fixed)
-        self.results_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Fixed)
+        self.results_table.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.ResizeMode.Fixed
+        )
+        self.results_table.horizontalHeader().setSectionResizeMode(
+            2, QHeaderView.ResizeMode.Fixed
+        )
         self.results_table.setColumnWidth(1, 90)  # Date
         self.results_table.setColumnWidth(2, 70)  # Size
-        self.results_table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.results_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.results_table.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.results_table.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
         self.results_table.setMinimumHeight(120)
         # Enable tooltips for truncated text
         self.results_table.setMouseTracking(True)
@@ -821,7 +847,7 @@ class EarthdataDockWidget(QDockWidget):
         self.cog_combo.setToolTip(
             "Select a COG file to display from the selected granule"
         )
-        self.cog_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.cog_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.cog_combo.setMinimumContentsLength(15)
         cog_layout.addWidget(self.cog_combo, 1)  # Stretch to fill
         results_layout.addLayout(cog_layout)
@@ -1168,7 +1194,7 @@ class EarthdataDockWidget(QDockWidget):
                 id_item = QTableWidgetItem(str(native_id))
                 id_item.setToolTip(str(native_id))  # Show full ID on hover
                 id_item.setData(
-                    Qt.UserRole, i
+                    Qt.ItemDataRole.UserRole, i
                 )  # Stable index into _search_results/_search_gdf
                 self.results_table.setItem(i, 0, id_item)
 
@@ -1178,18 +1204,18 @@ class EarthdataDockWidget(QDockWidget):
                 # Store raw bytes for proper numeric sorting
                 size_item = NumericTableWidgetItem(str(size_display))
                 size_item.setData(
-                    Qt.UserRole, size_bytes
+                    Qt.ItemDataRole.UserRole, size_bytes
                 )  # Store raw value for sorting
                 self.results_table.setItem(i, 2, size_item)
             except Exception:
                 id_item = QTableWidgetItem(f"Item {i+1}")
                 id_item.setToolTip(f"Item {i+1}")
-                id_item.setData(Qt.UserRole, i)
+                id_item.setData(Qt.ItemDataRole.UserRole, i)
                 self.results_table.setItem(i, 0, id_item)
                 self.results_table.setItem(i, 1, QTableWidgetItem("N/A"))
 
                 size_item = NumericTableWidgetItem("N/A")
-                size_item.setData(Qt.UserRole, 0)  # Store 0 for N/A
+                size_item.setData(Qt.ItemDataRole.UserRole, 0)  # Store 0 for N/A
                 self.results_table.setItem(i, 2, size_item)
 
         # Re-enable sorting after population
@@ -1369,13 +1395,13 @@ class EarthdataDockWidget(QDockWidget):
                 # Remove layer from project
                 QgsProject.instance().removeMapLayer(self._footprints_layer.id())
             except Exception:
-                pass
+                pass  # nosec B110 - layer cleanup is best-effort
 
             # Delete the layer object to release file handles (important on Windows)
             try:
                 del self._footprints_layer
             except Exception:
-                pass
+                pass  # nosec B110 - layer cleanup is best-effort
             self._footprints_layer = None
 
             # Force garbage collection to ensure file handles are released on Windows
@@ -1435,7 +1461,7 @@ class EarthdataDockWidget(QDockWidget):
         if item is None:
             return table_row
 
-        result_idx = item.data(Qt.UserRole)
+        result_idx = item.data(Qt.ItemDataRole.UserRole)
         if result_idx is None:
             return table_row
 
@@ -1503,18 +1529,18 @@ class EarthdataDockWidget(QDockWidget):
         # Toggle sort order: if already sorted by this column, reverse it
         if header.sortIndicatorSection() == logical_index:
             new_order = (
-                Qt.DescendingOrder
-                if current_order == Qt.AscendingOrder
-                else Qt.AscendingOrder
+                Qt.SortOrder.DescendingOrder
+                if current_order == Qt.SortOrder.AscendingOrder
+                else Qt.SortOrder.AscendingOrder
             )
         else:
             # Default to ascending for new column
-            new_order = Qt.AscendingOrder
+            new_order = Qt.SortOrder.AscendingOrder
 
         # Apply the sort
         self.results_table.sortItems(logical_index, new_order)
         self._log(
-            f"Sorted by column {logical_index} ({'descending' if new_order == Qt.DescendingOrder else 'ascending'})"
+            f"Sorted by column {logical_index} ({'descending' if new_order == Qt.SortOrder.DescendingOrder else 'ascending'})"
         )
 
     def _populate_cog_dropdown(self, row_index):
@@ -1595,7 +1621,7 @@ class EarthdataDockWidget(QDockWidget):
         self.progress_bar.setRange(0, 0)
 
         # Set wait cursor
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         # Read credentials from Settings input boxes as fallback
         username, password = self._get_settings_input_credentials()
@@ -1626,7 +1652,7 @@ class EarthdataDockWidget(QDockWidget):
             Tuple of (username, password) strings. Empty strings if unavailable.
         """
         username = ""
-        password = ""
+        password = ""  # nosec B105 - empty fallback when settings dock unavailable
         try:
             settings_dock = self.iface.mainWindow().findChild(
                 QDockWidget, "NASAEarthdataSettingsDock"
@@ -1637,7 +1663,7 @@ class EarthdataDockWidget(QDockWidget):
                 if hasattr(settings_dock, "password_input"):
                     password = settings_dock.password_input.text().strip()
         except Exception:
-            pass
+            pass  # nosec B110 - empty creds returned when settings dock unavailable
         return username, password
 
     def _on_cog_finished(self, results, cookie_file=None):
@@ -1773,10 +1799,10 @@ class EarthdataDockWidget(QDockWidget):
             "Confirm Download",
             f"Download {selection_msg} granule(s)?\n\n"
             f"Tip: Select specific rows in the table to download only those items.",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
         )
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         # Get output directory
@@ -1824,11 +1850,11 @@ class EarthdataDockWidget(QDockWidget):
                 self,
                 "Download Complete",
                 f"Downloaded {len(files)} file(s).\n\nAdd raster files to the map?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.Yes,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.Yes,
             )
 
-            if reply == QMessageBox.Yes:
+            if reply == QMessageBox.StandardButton.Yes:
                 for file_path in files:
                     if any(
                         str(file_path).lower().endswith(ext)

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -49,17 +49,12 @@ from qgis.core import (
     QgsRectangle,
 )
 
+from ..core.net import https_only_urlopen
+
 # NASA Earthdata TSV URL
 NASA_DATA_URL = (
     "https://github.com/opengeos/NASA-Earth-Data/raw/main/nasa_earth_data.tsv"
 )
-
-
-def _require_https(url: str) -> None:
-    """Reject any URL that is not https:// before passing it to urllib."""
-    if not url.lower().startswith("https://"):
-        raise ValueError(f"Refusing non-https URL: {url!r}")
-
 
 # Cache settings
 CACHE_DIR = Path(tempfile.gettempdir()) / "nasa_earthdata_cache"
@@ -156,7 +151,6 @@ class CatalogLoadWorker(QThread):
         """Load the catalog from cache or download."""
         try:
             import csv
-            import urllib.request
 
             # Ensure cache directory exists
             CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -177,10 +171,7 @@ class CatalogLoadWorker(QThread):
                     rows = list(reader)
             else:
                 self.progress.emit("Downloading NASA Earthdata catalog...")
-                _require_https(NASA_DATA_URL)
-                with urllib.request.urlopen(
-                    NASA_DATA_URL, timeout=30
-                ) as resp:  # nosec B310 - https-only enforced above
+                with https_only_urlopen(NASA_DATA_URL, timeout=30) as resp:
                     text = resp.read().decode("utf-8")
                 # Save raw TSV to cache
                 with open(CATALOG_CACHE_FILE, "w", encoding="utf-8") as f:

--- a/nasa_earthdata/dialogs/settings_dock.py
+++ b/nasa_earthdata/dialogs/settings_dock.py
@@ -52,7 +52,9 @@ class SettingsDockWidget(QDockWidget):
         self.settings = QSettings()
         self._deps_worker = None
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._setup_ui()
         self._load_settings()
@@ -73,7 +75,7 @@ class SettingsDockWidget(QDockWidget):
         header_font.setPointSize(11)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Tab widget for organized settings
@@ -144,7 +146,7 @@ class SettingsDockWidget(QDockWidget):
         # Password
         self.password_input = QLineEdit()
         self.password_input.setPlaceholderText("NASA Earthdata password")
-        self.password_input.setEchoMode(QLineEdit.Password)
+        self.password_input.setEchoMode(QLineEdit.EchoMode.Password)
         creds_layout.addRow("Password:", self.password_input)
 
         # Test credentials button
@@ -538,7 +540,7 @@ class SettingsDockWidget(QDockWidget):
                 with open(netrc_path, "r") as f:
                     existing_content = f.read()
             except Exception:
-                pass
+                pass  # nosec B110 - unreadable .netrc treated as empty content
 
         # Parse existing entries, excluding any existing earthdata entry
         lines = existing_content.strip().split("\n") if existing_content.strip() else []
@@ -648,11 +650,11 @@ class SettingsDockWidget(QDockWidget):
             self,
             "Clear Cache",
             f"Are you sure you want to clear the cache?\n\n{cache_dir}",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             try:
                 import shutil
 
@@ -668,7 +670,7 @@ class SettingsDockWidget(QDockWidget):
         """Load settings from QSettings."""
         # Credentials precedence: .netrc -> environment -> QSettings username
         username = ""
-        password = ""
+        password = ""  # nosec B105 - empty fallback, real value loaded below
         source = None
 
         netrc_username, netrc_password = self._get_netrc_earthdata_credentials()
@@ -824,11 +826,11 @@ class SettingsDockWidget(QDockWidget):
             self,
             "Reset Settings",
             "Are you sure you want to reset all settings to defaults?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         # Credentials

--- a/nasa_earthdata/dialogs/update_checker.py
+++ b/nasa_earthdata/dialogs/update_checker.py
@@ -36,6 +36,12 @@ METADATA_URL = f"https://raw.githubusercontent.com/{GITHUB_REPO}/{GITHUB_BRANCH}
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
 
 
+def _require_https(url: str) -> None:
+    """Reject any URL that is not https:// before passing it to urllib."""
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"Refusing non-https URL: {url!r}")
+
+
 class VersionCheckWorker(QThread):
     """Worker thread for checking the latest version from GitHub."""
 
@@ -45,7 +51,10 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            _require_https(METADATA_URL)
+            with urlopen(
+                METADATA_URL, timeout=15
+            ) as response:  # nosec B310 - https-only enforced above
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -106,7 +115,10 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            _require_https(ZIP_URL)
+            urlretrieve(
+                ZIP_URL, zip_path, reporthook
+            )  # nosec B310 - https-only enforced above
 
             self.progress.emit(60, "Extracting files...")
 
@@ -230,7 +242,7 @@ class UpdateCheckerDialog(QDialog):
         header_font.setPointSize(14)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Version info group
@@ -275,7 +287,7 @@ class UpdateCheckerDialog(QDialog):
         # Progress label
         self.progress_label = QLabel("")
         self.progress_label.setVisible(False)
-        self.progress_label.setAlignment(Qt.AlignCenter)
+        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.progress_label)
 
         # Buttons
@@ -305,7 +317,7 @@ class UpdateCheckerDialog(QDialog):
         )
         info_label.setWordWrap(True)
         info_label.setOpenExternalLinks(True)
-        info_label.setAlignment(Qt.AlignCenter)
+        info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(info_label)
 
     def check_for_updates(self):
@@ -396,11 +408,11 @@ class UpdateCheckerDialog(QDialog):
             f"This will download and install version {self.latest_version}.\n\n"
             "IMPORTANT: You will need to restart QGIS after the update completes.\n\n"
             "Do you want to continue?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         self.check_btn.setEnabled(False)
@@ -481,10 +493,10 @@ class UpdateCheckerDialog(QDialog):
                 self,
                 "Download in Progress",
                 "A download is in progress. Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self.download_worker.terminate()

--- a/nasa_earthdata/dialogs/update_checker.py
+++ b/nasa_earthdata/dialogs/update_checker.py
@@ -10,7 +10,6 @@ import re
 import shutil
 import tempfile
 import zipfile
-from urllib.request import urlopen, urlretrieve
 from urllib.error import URLError, HTTPError
 
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
@@ -28,18 +27,14 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtGui import QFont
 
+from ..core.net import https_only_urlopen, https_only_urlretrieve
+
 # GitHub URLs for the plugin
 GITHUB_REPO = "opengeos/qgis-nasa-earthdata-plugin"
 GITHUB_BRANCH = "main"
 PLUGIN_PATH = "nasa_earthdata"
 METADATA_URL = f"https://raw.githubusercontent.com/{GITHUB_REPO}/{GITHUB_BRANCH}/{PLUGIN_PATH}/metadata.txt"
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
-
-
-def _require_https(url: str) -> None:
-    """Reject any URL that is not https:// before passing it to urllib."""
-    if not url.lower().startswith("https://"):
-        raise ValueError(f"Refusing non-https URL: {url!r}")
 
 
 class VersionCheckWorker(QThread):
@@ -51,10 +46,7 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            _require_https(METADATA_URL)
-            with urlopen(
-                METADATA_URL, timeout=15
-            ) as response:  # nosec B310 - https-only enforced above
+            with https_only_urlopen(METADATA_URL, timeout=15) as response:
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -115,10 +107,7 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            _require_https(ZIP_URL)
-            urlretrieve(
-                ZIP_URL, zip_path, reporthook
-            )  # nosec B310 - https-only enforced above
+            https_only_urlretrieve(ZIP_URL, zip_path, reporthook=reporthook)
 
             self.progress.emit(60, "Extracting files...")
 

--- a/nasa_earthdata/metadata.txt
+++ b/nasa_earthdata/metadata.txt
@@ -1,8 +1,9 @@
 [general]
 name=NASA Earthdata
 qgisMinimumVersion=3.28
+qgisMaximumVersion=4.99
 description=Search, visualize, and download NASA Earthdata products in QGIS. Supports COG visualization and data footprint display.
-version=0.6.0
+version=0.7.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -36,6 +37,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.7.0
+        - Compatible with QGIS 4.0 (Qt6) while remaining compatible with QGIS 3.28+ (Qt5)
+        - Added PyQt6 import smoke tests and Bandit security scan in CI
     0.6.0
         - Use uv for faster dependency installation (#21)
         - Use batch installation for uv and pip (#22)

--- a/nasa_earthdata/nasa_earthdata.py
+++ b/nasa_earthdata/nasa_earthdata.py
@@ -190,7 +190,9 @@ class NASAEarthdata:
                 self._earthdata_dock.visibilityChanged.connect(
                     self._on_earthdata_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._earthdata_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._earthdata_dock
+                )
                 self._earthdata_dock.show()
                 self._earthdata_dock.raise_()
 
@@ -232,7 +234,9 @@ class NASAEarthdata:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+                )
                 self._settings_dock.show()
                 self._settings_dock.raise_()
                 self._connect_deps_signal()
@@ -287,16 +291,16 @@ class NASAEarthdata:
                 f"  {missing_names}\n\n"
                 f"The plugin needs these packages to search and download data.\n\n"
                 f"Would you like to open Settings to install them?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.Yes,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.Yes,
             )
 
-            if reply == QMessageBox.Yes:
+            if reply == QMessageBox.StandardButton.Yes:
                 self._open_settings_deps_tab()
 
         except Exception:
             # Don't let dependency check errors prevent the dock from opening
-            pass
+            pass  # nosec B110 - dependency check is best-effort UX hint
 
     def _open_settings_deps_tab(self):
         """Open the Settings dock and switch to the Dependencies tab."""
@@ -311,7 +315,9 @@ class NASAEarthdata:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+                )
                 self._connect_deps_signal()
             except Exception as e:
                 QMessageBox.critical(
@@ -395,7 +401,7 @@ class NASAEarthdata:
 
         try:
             dialog = UpdateCheckerDialog(self.plugin_dir, self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
         except Exception as e:
             QMessageBox.critical(
                 self.iface.mainWindow(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared pytest fixtures.
+
+Stubs the ``qgis`` package so the plugin's modules can be imported without a
+running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
+behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
+from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
+``QtWidgets`` in Qt6).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import PyQt6.QtCore
+import PyQt6.QtGui
+import PyQt6.QtNetwork
+import PyQt6.QtWidgets
+
+
+def _install_qgis_stub() -> None:
+    qgis = types.ModuleType("qgis")
+    qgis.__path__ = []
+    sys.modules["qgis"] = qgis
+
+    qgis_pyqt = types.ModuleType("qgis.PyQt")
+    qgis_pyqt.__path__ = []
+    sys.modules["qgis.PyQt"] = qgis_pyqt
+    qgis.PyQt = qgis_pyqt
+
+    pyqt_submodules = {
+        "QtCore": PyQt6.QtCore,
+        "QtGui": PyQt6.QtGui,
+        "QtNetwork": PyQt6.QtNetwork,
+        "QtWidgets": PyQt6.QtWidgets,
+    }
+    for name, real in pyqt_submodules.items():
+        alias = types.ModuleType(f"qgis.PyQt.{name}")
+        for attr in dir(real):
+            if not attr.startswith("_"):
+                setattr(alias, attr, getattr(real, attr))
+        sys.modules[f"qgis.PyQt.{name}"] = alias
+        setattr(qgis_pyqt, name, alias)
+
+    # Qt6: QAction, QActionGroup, and QShortcut live in QtGui. The real
+    # qgis.PyQt.QtWidgets shim re-exports them, so mirror that here.
+    qtwidgets_alias = sys.modules["qgis.PyQt.QtWidgets"]
+    for attr in ("QAction", "QActionGroup", "QShortcut"):
+        setattr(qtwidgets_alias, attr, getattr(PyQt6.QtGui, attr))
+
+    for submodule in ("QtSvg", "QtWebEngineWidgets"):
+        alias = MagicMock()
+        sys.modules[f"qgis.PyQt.{submodule}"] = alias
+        setattr(qgis_pyqt, submodule, alias)
+
+    for name in ("core", "gui", "utils"):
+        stub = MagicMock()
+        stub.__spec__ = None
+        sys.modules[f"qgis.{name}"] = stub
+        setattr(qgis, name, stub)
+
+
+_install_qgis_stub()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,26 @@
 """Shared pytest fixtures.
 
-Stubs the ``qgis`` package so the plugin's modules can be imported without a
-running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
-behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
-from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
-``QtWidgets`` in Qt6).
+When running outside of QGIS, stubs the ``qgis`` package onto PyQt6 so the
+plugin's modules can be imported. The stub reproduces the real
+``qgis.PyQt`` shim behavior on Qt6: it re-exports ``QAction``,
+``QActionGroup`` and ``QShortcut`` from ``PyQt6.QtGui`` under
+``qgis.PyQt.QtWidgets`` (they moved out of ``QtWidgets`` in Qt6).
+
+Pytest skips this file (and the modules that depend on it) when PyQt6 is
+not installed, and leaves a real ``qgis`` package alone if it's already
+importable, so this conftest never masks an integration environment.
 """
 
 import sys
 import types
 from unittest.mock import MagicMock
 
-import PyQt6.QtCore
-import PyQt6.QtGui
-import PyQt6.QtNetwork
-import PyQt6.QtWidgets
+import pytest
+
+PyQt6_QtCore = pytest.importorskip("PyQt6.QtCore")
+PyQt6_QtGui = pytest.importorskip("PyQt6.QtGui")
+PyQt6_QtNetwork = pytest.importorskip("PyQt6.QtNetwork")
+PyQt6_QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
 
 
 def _install_qgis_stub() -> None:
@@ -28,10 +34,10 @@ def _install_qgis_stub() -> None:
     qgis.PyQt = qgis_pyqt
 
     pyqt_submodules = {
-        "QtCore": PyQt6.QtCore,
-        "QtGui": PyQt6.QtGui,
-        "QtNetwork": PyQt6.QtNetwork,
-        "QtWidgets": PyQt6.QtWidgets,
+        "QtCore": PyQt6_QtCore,
+        "QtGui": PyQt6_QtGui,
+        "QtNetwork": PyQt6_QtNetwork,
+        "QtWidgets": PyQt6_QtWidgets,
     }
     for name, real in pyqt_submodules.items():
         alias = types.ModuleType(f"qgis.PyQt.{name}")
@@ -45,7 +51,7 @@ def _install_qgis_stub() -> None:
     # qgis.PyQt.QtWidgets shim re-exports them, so mirror that here.
     qtwidgets_alias = sys.modules["qgis.PyQt.QtWidgets"]
     for attr in ("QAction", "QActionGroup", "QShortcut"):
-        setattr(qtwidgets_alias, attr, getattr(PyQt6.QtGui, attr))
+        setattr(qtwidgets_alias, attr, getattr(PyQt6_QtGui, attr))
 
     for submodule in ("QtSvg", "QtWebEngineWidgets"):
         alias = MagicMock()
@@ -59,4 +65,11 @@ def _install_qgis_stub() -> None:
         setattr(qgis, name, stub)
 
 
-_install_qgis_stub()
+# Only stub when a real qgis isn't already importable. This keeps the test
+# suite usable both standalone (CI / dev box) and inside a real QGIS
+# Python environment, where masking the real package would hide
+# integration problems.
+try:
+    import qgis  # noqa: F401
+except ImportError:
+    _install_qgis_stub()

--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -1,0 +1,54 @@
+"""Import-smoke tests that verify every plugin module loads under PyQt6.
+
+This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
+instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
+PyQt6 during class-body evaluation.
+
+The plugin package is auto-discovered: the first sibling directory of
+``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
+so this file does not need to be edited per-plugin.
+"""
+
+import importlib
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _find_plugin_root() -> pathlib.Path:
+    """Return the plugin package directory (the one with metadata.txt)."""
+    candidates = [
+        p.parent for p in REPO_ROOT.glob("*/metadata.txt") if p.parent.name != "tests"
+    ]
+    if not candidates:
+        raise RuntimeError(
+            "Could not locate a QGIS plugin package (no */metadata.txt found "
+            f"under {REPO_ROOT})."
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"Multiple plugin packages found under {REPO_ROOT}: {candidates}. "
+            "Set PLUGIN_ROOT explicitly in this file."
+        )
+    return candidates[0]
+
+
+PLUGIN_ROOT = _find_plugin_root()
+
+
+def _module_names():
+    """Yield dotted module names for every .py file under the plugin package."""
+    for path in sorted(PLUGIN_ROOT.rglob("*.py")):
+        rel = path.relative_to(PLUGIN_ROOT.parent).with_suffix("")
+        parts = rel.parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        yield ".".join(parts)
+
+
+@pytest.mark.parametrize("module_name", list(_module_names()))
+def test_module_imports_under_pyqt6(module_name):
+    """Each plugin module must import cleanly when qgis.PyQt maps to PyQt6."""
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary

Migrate the plugin to a single codebase that loads cleanly on both **QGIS 3.28+ (Qt5/PyQt5)** and **QGIS 4.0 (Qt6/PyQt6)**, so it appears on the [QGIS 4 Ready plugin list](https://plugins.qgis.org/plugins/new_qgis_ready/) without dropping current users.

References:
- https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6
- https://plugins.qgis.org/docs/migrate-qgis4

### What changed

- **Enum qualification** across `Qt`, `QMessageBox`, `QHeaderView`, `QAbstractItemView`, `QLineEdit`, `QFormLayout`, `QComboBox` and `Qgis` enums to their fully qualified form (`Qt.AlignmentFlag.AlignCenter`, `QMessageBox.StandardButton.Yes`, `Qgis.MessageLevel.Info`, etc.) so the same source loads under PyQt5 >= 5.15 and PyQt6.
- **`dialog.exec_()` -> `dialog.exec()`**.
- **`metadata.txt`**: `qgisMaximumVersion=4.99`, `version=0.7.0`, plus a 0.7.0 changelog entry. (`supportsQt6` is intentionally NOT set; that flag was removed in QGIS 4.0.)
- **Bandit clean**: resolved every B404/B603/B105/B110/B112/B310 finding (the plugins.qgis.org upload pipeline runs Bandit and rejects on findings). Network calls now go through an https-only guard before urlopen/urlretrieve.
- **Tests**: added `tests/test_pyqt6_imports.py` plus a `qgis.PyQt` stub conftest that auto-discovers the plugin package and imports every module under PyQt6.
- **CI**: added `.github/workflows/ci.yml` running pre-commit, Bandit, and the PyQt6 smoke test on Python 3.10-3.13. Bandit hook also added to `.pre-commit-config.yaml`.

### Test plan

Local checks (already green on this branch):
- [x] `pre-commit run --all-files`
- [x] `bandit -r nasa_earthdata` -> `No issues identified.`
- [x] `pytest tests/ -v` under PyQt6 -> 11/11 passed
- [x] `python -m compileall nasa_earthdata` under PyQt5

Manual smoke (please exercise before merging):
- [ ] Install branch into QGIS 3.28+ (Qt5): toolbar action opens, search dock works, settings dock saves credentials, dependency installer runs, update checker dialog opens.
- [ ] Install branch into a QGIS 4.0 nightly (Qt6): repeat the same checks, paying attention to `QMessageBox` Yes/No confirmations, `QFileDialog` directory pickers, results-table sort/select behavior, and dock dock-area placement.