### PR TITLE
Distinguish broken from missing earthaccess install (#26)

### DIFF
--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -994,7 +994,7 @@ def import_earthaccess():
 
         message = (
             f"earthaccess {version} is installed but failed to import: {exc}. "
-            "Try Reinstall Dependencies."
+            "Try Install Dependencies in Settings."
         )
         _log(
             f"{message} QGIS Python: {sys.version}",

--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess  # nosec B404 - only invoked with hard-coded internal commands
 import sys
 import time
+import traceback
 from typing import Tuple, Optional, Callable, List
 
 from qgis.core import QgsMessageLog, Qgis
@@ -26,6 +27,47 @@ REQUIRED_PACKAGES = [
     ("pandas", ""),
     ("geopandas", ""),
 ]
+
+
+class EarthaccessNotInstalledError(ImportError):
+    """Raised when the ``earthaccess`` package is not present in the venv.
+
+    Inherits from :class:`ImportError` so that callers using a generic
+    ``except Exception``/``except ImportError`` still see a useful message
+    via :func:`str`.
+    """
+
+    def __init__(self, user_message: str):
+        """Initialize the error.
+
+        Args:
+            user_message: Short string suitable for display in a dialog
+                or status label.
+        """
+        super().__init__(user_message)
+        self.user_message = user_message
+
+
+class EarthaccessImportError(ImportError):
+    """Raised when ``earthaccess`` is installed but fails to import.
+
+    The dist-info directory is present in the venv site-packages, but the
+    actual ``import earthaccess`` raises (typically because of an ABI
+    mismatch with QGIS's Python or a partially installed transitive
+    dependency). Inherits from :class:`ImportError` so generic ``except``
+    handlers still surface :attr:`user_message` via :func:`str`.
+    """
+
+    def __init__(self, user_message: str, original: BaseException):
+        """Initialize the error.
+
+        Args:
+            user_message: Short string suitable for display to the user.
+            original: The underlying exception raised by ``import``.
+        """
+        super().__init__(user_message)
+        self.user_message = user_message
+        self.original = original
 
 
 def _log(message, level=Qgis.MessageLevel.Info):
@@ -968,6 +1010,110 @@ def ensure_venv_packages_available():
     return True
 
 
+def _earthaccess_dist_info_present():
+    """Return True if an ``earthaccess`` dist-info directory exists in the venv.
+
+    A present dist-info means ``importlib.metadata.version("earthaccess")``
+    will succeed even though Python may not actually be able to import the
+    package (for example, because of an ABI mismatch with QGIS's Python).
+
+    Returns:
+        True if an ``earthaccess-*.dist-info`` directory was found.
+    """
+    site_packages = get_venv_site_packages()
+    if site_packages is None or not os.path.isdir(site_packages):
+        return False
+    try:
+        for entry in os.listdir(site_packages):
+            if entry.startswith("earthaccess") and entry.endswith(".dist-info"):
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def _log_earthaccess_import_failure(original):
+    """Log full diagnostics for a failed ``import earthaccess``.
+
+    Args:
+        original: The exception raised by the failed import.
+    """
+    site_packages = get_venv_site_packages()
+    venv_python = get_venv_python_path()
+
+    venv_version = "<unknown>"
+    if os.path.isfile(venv_python):
+        try:
+            result = subprocess.run(  # nosec B603 - hard-coded internal args
+                [venv_python, "-c", "import sys; print(sys.version)"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=_get_clean_env_for_venv(),
+                **_get_subprocess_kwargs(),
+            )
+            if result.returncode == 0:
+                venv_version = result.stdout.strip() or "<empty>"
+            else:
+                venv_version = (
+                    f"<probe failed: rc={result.returncode}, "
+                    f"err={(result.stderr or '').strip()[:200]}>"
+                )
+        except Exception as e:  # noqa: BLE001 - diagnostic best-effort
+            venv_version = f"<venv python unreachable: {e}>"
+
+    _log(
+        "earthaccess is installed but failed to import.\n"
+        f"  Original error: {type(original).__name__}: {original}\n"
+        f"  QGIS Python:    {sys.version}\n"
+        f"  Venv Python:    {venv_version}\n"
+        f"  Site-packages:  {site_packages}\n"
+        "  Traceback:\n"
+        f"{traceback.format_exc()}",
+        Qgis.MessageLevel.Critical,
+    )
+
+
+def import_earthaccess():
+    """Import the ``earthaccess`` package, with friendly errors on failure.
+
+    Calls :func:`ensure_venv_packages_available` to put the venv
+    site-packages on ``sys.path``, then attempts ``import earthaccess``.
+
+    Returns:
+        The imported ``earthaccess`` module.
+
+    Raises:
+        EarthaccessNotInstalledError: If no ``earthaccess`` dist-info is
+            present in the venv site-packages.
+        EarthaccessImportError: If the dist-info is present but the import
+            itself fails (broken install, ABI mismatch, etc.). Full
+            diagnostics are logged to the QGIS message log.
+    """
+    ensure_venv_packages_available()
+
+    try:
+        import earthaccess  # noqa: WPS433 - intentional runtime import
+
+        return earthaccess
+    except ImportError as exc:
+        if not _earthaccess_dist_info_present():
+            raise EarthaccessNotInstalledError(
+                "earthaccess package not installed - "
+                "please run Install Dependencies in Settings."
+            ) from exc
+
+        _log_earthaccess_import_failure(exc)
+        raise EarthaccessImportError(
+            (
+                "earthaccess is installed but failed to import: "
+                f"{exc}. See View > Panels > Log Messages > "
+                "'NASA Earthdata' for details. Try Reinstall Dependencies."
+            ),
+            exc,
+        ) from exc
+
+
 # ---------------------------------------------------------------------------
 # Status checking
 # ---------------------------------------------------------------------------
@@ -1007,32 +1153,92 @@ def get_venv_status():
     return True, "Virtual environment ready"
 
 
+def _probe_earthaccess_in_venv():
+    """Try to ``import earthaccess`` in the venv's own Python.
+
+    The Dependencies tab refreshes synchronously on the UI thread, so we
+    deliberately probe in a subprocess (the venv Python) rather than the
+    QGIS process: a broken transitive dep can otherwise leak partial
+    state into ``sys.modules``. The venv probe still catches the common
+    failures (partial install, broken transitive deps).
+
+    If the venv Python does not exist (yet), there is nothing to probe;
+    return success so a system-wide install of ``earthaccess`` is still
+    reported as installed by :func:`check_dependencies`.
+
+    Returns:
+        A tuple of (ok: bool, error_excerpt: str). ``error_excerpt`` is
+        empty when ``ok`` is True.
+    """
+    venv_python = get_venv_python_path()
+    if not os.path.isfile(venv_python):
+        return True, ""
+
+    try:
+        result = subprocess.run(  # nosec B603 - hard-coded internal args
+            [venv_python, "-c", _get_verification_code("earthaccess")],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=_get_clean_env_for_venv(),
+            **_get_subprocess_kwargs(),
+        )
+    except subprocess.TimeoutExpired:
+        return False, "import probe timed out"
+    except Exception as e:  # noqa: BLE001 - diagnostic best-effort
+        return False, f"probe failed: {e}"
+
+    if result.returncode == 0:
+        return True, ""
+
+    err = (result.stderr or result.stdout or "").strip()
+    return False, err[-200:] if err else f"exit code {result.returncode}"
+
+
 def check_dependencies():
     """Check if all required packages are installed and importable.
 
-    Attempts to use importlib.metadata after ensuring venv packages
-    are on sys.path. This is a lightweight check suitable for UI display.
+    Uses :mod:`importlib.metadata` after ensuring venv packages are on
+    ``sys.path`` to enumerate installed/missing packages. For
+    ``earthaccess`` it also runs a subprocess probe in the venv's Python
+    so the UI does not lie when the dist-info is present but the package
+    cannot actually be imported (issue #26).
 
     Returns:
-        A tuple of (all_ok, missing, installed) where:
-            all_ok: True if all required packages are installed.
+        A tuple of (all_ok, missing, installed, broken) where:
+            all_ok: True if all required packages are installed and (for
+                earthaccess) actually importable.
             missing: List of (package_name, version_spec) for missing packages.
-            installed: List of (package_name, version_string) for installed packages.
+            installed: List of (package_name, version_string) for installed
+                and importable packages.
+            broken: List of (package_name, version_string, error_excerpt)
+                for packages whose dist-info is present but whose import
+                fails. Currently only ``earthaccess`` is probed.
     """
     ensure_venv_packages_available()
 
     missing = []
     installed = []
+    broken = []
 
     for package_name, version_spec in REQUIRED_PACKAGES:
         try:
             version = importlib.metadata.version(package_name)
-            installed.append((package_name, version))
         except importlib.metadata.PackageNotFoundError:
             missing.append((package_name, version_spec))
+            continue
 
-    all_ok = len(missing) == 0
-    return all_ok, missing, installed
+        if package_name == "earthaccess":
+            ok, err = _probe_earthaccess_in_venv()
+            if ok:
+                installed.append((package_name, version))
+            else:
+                broken.append((package_name, version, err))
+        else:
+            installed.append((package_name, version))
+
+    all_ok = not missing and not broken
+    return all_ok, missing, installed, broken
 
 
 # ---------------------------------------------------------------------------

--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -14,7 +14,6 @@ import shutil
 import subprocess  # nosec B404 - only invoked with hard-coded internal commands
 import sys
 import time
-import traceback
 from typing import Tuple, Optional, Callable, List
 
 from qgis.core import QgsMessageLog, Qgis
@@ -27,47 +26,6 @@ REQUIRED_PACKAGES = [
     ("pandas", ""),
     ("geopandas", ""),
 ]
-
-
-class EarthaccessNotInstalledError(ImportError):
-    """Raised when the ``earthaccess`` package is not present in the venv.
-
-    Inherits from :class:`ImportError` so that callers using a generic
-    ``except Exception``/``except ImportError`` still see a useful message
-    via :func:`str`.
-    """
-
-    def __init__(self, user_message: str):
-        """Initialize the error.
-
-        Args:
-            user_message: Short string suitable for display in a dialog
-                or status label.
-        """
-        super().__init__(user_message)
-        self.user_message = user_message
-
-
-class EarthaccessImportError(ImportError):
-    """Raised when ``earthaccess`` is installed but fails to import.
-
-    The dist-info directory is present in the venv site-packages, but the
-    actual ``import earthaccess`` raises (typically because of an ABI
-    mismatch with QGIS's Python or a partially installed transitive
-    dependency). Inherits from :class:`ImportError` so generic ``except``
-    handlers still surface :attr:`user_message` via :func:`str`.
-    """
-
-    def __init__(self, user_message: str, original: BaseException):
-        """Initialize the error.
-
-        Args:
-            user_message: Short string suitable for display to the user.
-            original: The underlying exception raised by ``import``.
-        """
-        super().__init__(user_message)
-        self.user_message = user_message
-        self.original = original
 
 
 def _log(message, level=Qgis.MessageLevel.Info):
@@ -1010,85 +968,14 @@ def ensure_venv_packages_available():
     return True
 
 
-def _earthaccess_dist_info_present():
-    """Return True if an ``earthaccess`` dist-info directory exists in the venv.
-
-    A present dist-info means ``importlib.metadata.version("earthaccess")``
-    will succeed even though Python may not actually be able to import the
-    package (for example, because of an ABI mismatch with QGIS's Python).
-
-    Returns:
-        True if an ``earthaccess-*.dist-info`` directory was found.
-    """
-    site_packages = get_venv_site_packages()
-    if site_packages is None or not os.path.isdir(site_packages):
-        return False
-    try:
-        for entry in os.listdir(site_packages):
-            if entry.startswith("earthaccess") and entry.endswith(".dist-info"):
-                return True
-    except OSError:
-        pass
-    return False
-
-
-def _log_earthaccess_import_failure(original):
-    """Log full diagnostics for a failed ``import earthaccess``.
-
-    Args:
-        original: The exception raised by the failed import.
-    """
-    site_packages = get_venv_site_packages()
-    venv_python = get_venv_python_path()
-
-    venv_version = "<unknown>"
-    if os.path.isfile(venv_python):
-        try:
-            result = subprocess.run(  # nosec B603 - hard-coded internal args
-                [venv_python, "-c", "import sys; print(sys.version)"],
-                capture_output=True,
-                text=True,
-                timeout=15,
-                env=_get_clean_env_for_venv(),
-                **_get_subprocess_kwargs(),
-            )
-            if result.returncode == 0:
-                venv_version = result.stdout.strip() or "<empty>"
-            else:
-                venv_version = (
-                    f"<probe failed: rc={result.returncode}, "
-                    f"err={(result.stderr or '').strip()[:200]}>"
-                )
-        except Exception as e:  # noqa: BLE001 - diagnostic best-effort
-            venv_version = f"<venv python unreachable: {e}>"
-
-    _log(
-        "earthaccess is installed but failed to import.\n"
-        f"  Original error: {type(original).__name__}: {original}\n"
-        f"  QGIS Python:    {sys.version}\n"
-        f"  Venv Python:    {venv_version}\n"
-        f"  Site-packages:  {site_packages}\n"
-        "  Traceback:\n"
-        f"{traceback.format_exc()}",
-        Qgis.MessageLevel.Critical,
-    )
-
-
 def import_earthaccess():
-    """Import the ``earthaccess`` package, with friendly errors on failure.
-
-    Calls :func:`ensure_venv_packages_available` to put the venv
-    site-packages on ``sys.path``, then attempts ``import earthaccess``.
+    """Import ``earthaccess`` with a clear message when import fails.
 
     Returns:
         The imported ``earthaccess`` module.
 
     Raises:
-        EarthaccessNotInstalledError: If no ``earthaccess`` dist-info is
-            present in the venv site-packages.
-        EarthaccessImportError: If the dist-info is present but the import
-            itself fails (broken install, ABI mismatch, etc.). Full
-            diagnostics are logged to the QGIS message log.
+        ImportError: If ``earthaccess`` is missing or installed but broken.
     """
     ensure_venv_packages_available()
 
@@ -1097,21 +984,23 @@ def import_earthaccess():
 
         return earthaccess
     except ImportError as exc:
-        if not _earthaccess_dist_info_present():
-            raise EarthaccessNotInstalledError(
+        try:
+            version = importlib.metadata.version("earthaccess")
+        except importlib.metadata.PackageNotFoundError:
+            raise ImportError(
                 "earthaccess package not installed - "
                 "please run Install Dependencies in Settings."
             ) from exc
 
-        _log_earthaccess_import_failure(exc)
-        raise EarthaccessImportError(
-            (
-                "earthaccess is installed but failed to import: "
-                f"{exc}. See View > Panels > Log Messages > "
-                "'NASA Earthdata' for details. Try Reinstall Dependencies."
-            ),
-            exc,
-        ) from exc
+        message = (
+            f"earthaccess {version} is installed but failed to import: {exc}. "
+            "Try Reinstall Dependencies."
+        )
+        _log(
+            f"{message} QGIS Python: {sys.version}",
+            Qgis.MessageLevel.Critical,
+        )
+        raise ImportError(message) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -1153,92 +1042,32 @@ def get_venv_status():
     return True, "Virtual environment ready"
 
 
-def _probe_earthaccess_in_venv():
-    """Try to ``import earthaccess`` in the venv's own Python.
-
-    The Dependencies tab refreshes synchronously on the UI thread, so we
-    deliberately probe in a subprocess (the venv Python) rather than the
-    QGIS process: a broken transitive dep can otherwise leak partial
-    state into ``sys.modules``. The venv probe still catches the common
-    failures (partial install, broken transitive deps).
-
-    If the venv Python does not exist (yet), there is nothing to probe;
-    return success so a system-wide install of ``earthaccess`` is still
-    reported as installed by :func:`check_dependencies`.
-
-    Returns:
-        A tuple of (ok: bool, error_excerpt: str). ``error_excerpt`` is
-        empty when ``ok`` is True.
-    """
-    venv_python = get_venv_python_path()
-    if not os.path.isfile(venv_python):
-        return True, ""
-
-    try:
-        result = subprocess.run(  # nosec B603 - hard-coded internal args
-            [venv_python, "-c", _get_verification_code("earthaccess")],
-            capture_output=True,
-            text=True,
-            timeout=20,
-            env=_get_clean_env_for_venv(),
-            **_get_subprocess_kwargs(),
-        )
-    except subprocess.TimeoutExpired:
-        return False, "import probe timed out"
-    except Exception as e:  # noqa: BLE001 - diagnostic best-effort
-        return False, f"probe failed: {e}"
-
-    if result.returncode == 0:
-        return True, ""
-
-    err = (result.stderr or result.stdout or "").strip()
-    return False, err[-200:] if err else f"exit code {result.returncode}"
-
-
 def check_dependencies():
-    """Check if all required packages are installed and importable.
+    """Check if all required packages are installed.
 
-    Uses :mod:`importlib.metadata` after ensuring venv packages are on
-    ``sys.path`` to enumerate installed/missing packages. For
-    ``earthaccess`` it also runs a subprocess probe in the venv's Python
-    so the UI does not lie when the dist-info is present but the package
-    cannot actually be imported (issue #26).
+    Attempts to use importlib.metadata after ensuring venv packages
+    are on sys.path. This is a lightweight check suitable for UI display.
 
     Returns:
-        A tuple of (all_ok, missing, installed, broken) where:
-            all_ok: True if all required packages are installed and (for
-                earthaccess) actually importable.
+        A tuple of (all_ok, missing, installed) where:
+            all_ok: True if all required packages are installed.
             missing: List of (package_name, version_spec) for missing packages.
-            installed: List of (package_name, version_string) for installed
-                and importable packages.
-            broken: List of (package_name, version_string, error_excerpt)
-                for packages whose dist-info is present but whose import
-                fails. Currently only ``earthaccess`` is probed.
+            installed: List of (package_name, version_string) for installed packages.
     """
     ensure_venv_packages_available()
 
     missing = []
     installed = []
-    broken = []
 
     for package_name, version_spec in REQUIRED_PACKAGES:
         try:
             version = importlib.metadata.version(package_name)
+            installed.append((package_name, version))
         except importlib.metadata.PackageNotFoundError:
             missing.append((package_name, version_spec))
-            continue
 
-        if package_name == "earthaccess":
-            ok, err = _probe_earthaccess_in_venv()
-            if ok:
-                installed.append((package_name, version))
-            else:
-                broken.append((package_name, version, err))
-        else:
-            installed.append((package_name, version))
-
-    all_ok = not missing and not broken
-    return all_ok, missing, installed, broken
+    all_ok = len(missing) == 0
+    return all_ok, missing, installed
 
 
 # ---------------------------------------------------------------------------

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -224,10 +224,9 @@ class DataSearchWorker(QThread):
         """Execute the search."""
         try:
             self.progress.emit("Importing earthaccess...")
-            from ..core.venv_manager import ensure_venv_packages_available
+            from ..core.venv_manager import import_earthaccess
 
-            ensure_venv_packages_available()
-            import earthaccess
+            earthaccess = import_earthaccess()
 
             self.progress.emit("Searching NASA Earthdata...")
 
@@ -395,10 +394,9 @@ class COGDisplayWorker(QThread):
     def run(self):
         """Authenticate, download COG files to temp dir, and emit paths."""
         try:
-            from ..core.venv_manager import ensure_venv_packages_available
+            from ..core.venv_manager import import_earthaccess
 
-            ensure_venv_packages_available()
-            import earthaccess
+            earthaccess = import_earthaccess()
 
             self.progress.emit("Authenticating with NASA Earthdata...")
             if not self._login(earthaccess):
@@ -508,10 +506,9 @@ class DataDownloadWorker(QThread):
     def run(self):
         """Execute the download."""
         try:
-            from ..core.venv_manager import ensure_venv_packages_available
+            from ..core.venv_manager import import_earthaccess
 
-            ensure_venv_packages_available()
-            import earthaccess
+            earthaccess = import_earthaccess()
 
             self.progress.emit(10, "Authenticating...")
 

--- a/nasa_earthdata/dialogs/settings_dock.py
+++ b/nasa_earthdata/dialogs/settings_dock.py
@@ -370,7 +370,7 @@ class SettingsDockWidget(QDockWidget):
         """Refresh the dependency status display."""
         from ..core.venv_manager import check_dependencies
 
-        all_ok, missing, installed = check_dependencies()
+        all_ok, missing, installed, broken = check_dependencies()
 
         for package_name, version in installed:
             if package_name in self._deps_labels:
@@ -384,12 +384,26 @@ class SettingsDockWidget(QDockWidget):
                 self._deps_labels[package_name].setText("Not installed")
                 self._deps_labels[package_name].setStyleSheet("color: red;")
 
+        for package_name, version, _err in broken:
+            if package_name in self._deps_labels:
+                self._deps_labels[package_name].setText(
+                    f"v{version} (broken - reinstall)"
+                )
+                self._deps_labels[package_name].setStyleSheet(
+                    "color: red; font-weight: bold;"
+                )
+
         self.install_deps_btn.setEnabled(not all_ok)
         if all_ok:
             self.install_deps_btn.setText("All Dependencies Installed")
-        else:
+        elif broken and not missing:
             self.install_deps_btn.setText(
-                f"Install Dependencies ({len(missing)} missing)"
+                f"Reinstall Dependencies ({len(broken)} broken)"
+            )
+        else:
+            problem_count = len(missing) + len(broken)
+            self.install_deps_btn.setText(
+                f"Install Dependencies ({problem_count} missing)"
             )
 
     def _install_dependencies(self):
@@ -496,10 +510,13 @@ class SettingsDockWidget(QDockWidget):
         self.creds_status_label.setStyleSheet("color: blue;")
 
         try:
-            from ..core.venv_manager import ensure_venv_packages_available
+            from ..core.venv_manager import (
+                EarthaccessImportError,
+                EarthaccessNotInstalledError,
+                import_earthaccess,
+            )
 
-            ensure_venv_packages_available()
-            import earthaccess
+            earthaccess = import_earthaccess()
 
             # Set environment variables for earthaccess
             os.environ["EARTHDATA_USERNAME"] = username
@@ -521,8 +538,13 @@ class SettingsDockWidget(QDockWidget):
                 self.creds_status_label.setText("✗ Authentication failed")
                 self.creds_status_label.setStyleSheet("color: red;")
 
-        except ImportError:
-            self.creds_status_label.setText("earthaccess package not installed")
+        except EarthaccessNotInstalledError as e:
+            self.creds_status_label.setText(e.user_message)
+            self.creds_status_label.setStyleSheet("color: red;")
+        except EarthaccessImportError as e:
+            # Truncate so it fits the status label; full traceback is in
+            # the QGIS Log Messages panel under "NASA Earthdata".
+            self.creds_status_label.setText(e.user_message[:200])
             self.creds_status_label.setStyleSheet("color: red;")
         except Exception as e:
             self.creds_status_label.setText(f"Error: {str(e)[:50]}")

--- a/nasa_earthdata/dialogs/settings_dock.py
+++ b/nasa_earthdata/dialogs/settings_dock.py
@@ -370,7 +370,7 @@ class SettingsDockWidget(QDockWidget):
         """Refresh the dependency status display."""
         from ..core.venv_manager import check_dependencies
 
-        all_ok, missing, installed, broken = check_dependencies()
+        all_ok, missing, installed = check_dependencies()
 
         for package_name, version in installed:
             if package_name in self._deps_labels:
@@ -384,26 +384,12 @@ class SettingsDockWidget(QDockWidget):
                 self._deps_labels[package_name].setText("Not installed")
                 self._deps_labels[package_name].setStyleSheet("color: red;")
 
-        for package_name, version, _err in broken:
-            if package_name in self._deps_labels:
-                self._deps_labels[package_name].setText(
-                    f"v{version} (broken - reinstall)"
-                )
-                self._deps_labels[package_name].setStyleSheet(
-                    "color: red; font-weight: bold;"
-                )
-
         self.install_deps_btn.setEnabled(not all_ok)
         if all_ok:
             self.install_deps_btn.setText("All Dependencies Installed")
-        elif broken and not missing:
-            self.install_deps_btn.setText(
-                f"Reinstall Dependencies ({len(broken)} broken)"
-            )
         else:
-            problem_count = len(missing) + len(broken)
             self.install_deps_btn.setText(
-                f"Install Dependencies ({problem_count} missing)"
+                f"Install Dependencies ({len(missing)} missing)"
             )
 
     def _install_dependencies(self):
@@ -510,11 +496,7 @@ class SettingsDockWidget(QDockWidget):
         self.creds_status_label.setStyleSheet("color: blue;")
 
         try:
-            from ..core.venv_manager import (
-                EarthaccessImportError,
-                EarthaccessNotInstalledError,
-                import_earthaccess,
-            )
+            from ..core.venv_manager import import_earthaccess
 
             earthaccess = import_earthaccess()
 
@@ -538,13 +520,8 @@ class SettingsDockWidget(QDockWidget):
                 self.creds_status_label.setText("✗ Authentication failed")
                 self.creds_status_label.setStyleSheet("color: red;")
 
-        except EarthaccessNotInstalledError as e:
-            self.creds_status_label.setText(e.user_message)
-            self.creds_status_label.setStyleSheet("color: red;")
-        except EarthaccessImportError as e:
-            # Truncate so it fits the status label; full traceback is in
-            # the QGIS Log Messages panel under "NASA Earthdata".
-            self.creds_status_label.setText(e.user_message[:200])
+        except ImportError as e:
+            self.creds_status_label.setText(str(e)[:200])
             self.creds_status_label.setStyleSheet("color: red;")
         except Exception as e:
             self.creds_status_label.setText(f"Error: {str(e)[:50]}")

--- a/tests/test_venv_manager.py
+++ b/tests/test_venv_manager.py
@@ -42,9 +42,7 @@ def test_import_earthaccess_classifies_missing_dist_info(
     force_earthaccess_import_failure, monkeypatch
 ):
     """When no dist-info is present, raise EarthaccessNotInstalledError."""
-    monkeypatch.setattr(
-        venv_manager, "_earthaccess_dist_info_present", lambda: False
-    )
+    monkeypatch.setattr(venv_manager, "_earthaccess_dist_info_present", lambda: False)
 
     with pytest.raises(venv_manager.EarthaccessNotInstalledError) as exc_info:
         venv_manager.import_earthaccess()
@@ -58,9 +56,7 @@ def test_import_earthaccess_classifies_broken_install(
     force_earthaccess_import_failure, monkeypatch
 ):
     """When dist-info is present but import fails, raise EarthaccessImportError."""
-    monkeypatch.setattr(
-        venv_manager, "_earthaccess_dist_info_present", lambda: True
-    )
+    monkeypatch.setattr(venv_manager, "_earthaccess_dist_info_present", lambda: True)
     # Avoid touching subprocess/QGIS log during the test.
     monkeypatch.setattr(
         venv_manager, "_log_earthaccess_import_failure", lambda exc: None

--- a/tests/test_venv_manager.py
+++ b/tests/test_venv_manager.py
@@ -1,0 +1,103 @@
+"""Tests for ``nasa_earthdata.core.venv_manager`` error classification.
+
+These tests do NOT exercise a real install. They monkey-patch the
+helpers used by ``import_earthaccess`` so we can assert the right
+classification (genuinely missing vs. installed-but-broken) without
+fabricating a working venv.
+"""
+
+import builtins
+import sys
+
+import pytest
+
+from nasa_earthdata.core import venv_manager
+
+
+@pytest.fixture
+def force_earthaccess_import_failure(monkeypatch):
+    """Make ``import earthaccess`` raise ImportError, even if installed.
+
+    The dev environment may already have ``earthaccess`` available
+    system-wide (e.g. in the ``geo`` conda env). This fixture intercepts
+    Python's import machinery so ``import earthaccess`` always fails for
+    the duration of the test, letting us verify the classification logic
+    in isolation.
+    """
+    monkeypatch.delitem(sys.modules, "earthaccess", raising=False)
+    monkeypatch.setattr(venv_manager, "ensure_venv_packages_available", lambda: True)
+
+    real_import = builtins.__import__
+
+    def raising_import(name, *args, **kwargs):
+        if name == "earthaccess" or name.startswith("earthaccess."):
+            raise ImportError("simulated: earthaccess fails to import")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", raising_import)
+    yield
+
+
+def test_import_earthaccess_classifies_missing_dist_info(
+    force_earthaccess_import_failure, monkeypatch
+):
+    """When no dist-info is present, raise EarthaccessNotInstalledError."""
+    monkeypatch.setattr(
+        venv_manager, "_earthaccess_dist_info_present", lambda: False
+    )
+
+    with pytest.raises(venv_manager.EarthaccessNotInstalledError) as exc_info:
+        venv_manager.import_earthaccess()
+
+    assert "not installed" in exc_info.value.user_message.lower()
+    # Inherits from ImportError so generic handlers still catch it.
+    assert isinstance(exc_info.value, ImportError)
+
+
+def test_import_earthaccess_classifies_broken_install(
+    force_earthaccess_import_failure, monkeypatch
+):
+    """When dist-info is present but import fails, raise EarthaccessImportError."""
+    monkeypatch.setattr(
+        venv_manager, "_earthaccess_dist_info_present", lambda: True
+    )
+    # Avoid touching subprocess/QGIS log during the test.
+    monkeypatch.setattr(
+        venv_manager, "_log_earthaccess_import_failure", lambda exc: None
+    )
+
+    with pytest.raises(venv_manager.EarthaccessImportError) as exc_info:
+        venv_manager.import_earthaccess()
+
+    assert "failed to import" in exc_info.value.user_message.lower()
+    assert isinstance(exc_info.value, ImportError)
+    assert exc_info.value.original is not None
+
+
+def test_check_dependencies_returns_four_tuple(monkeypatch):
+    """``check_dependencies`` must return (all_ok, missing, installed, broken)."""
+    # Force the metadata lookups and probe to deterministic values.
+    monkeypatch.setattr(venv_manager, "ensure_venv_packages_available", lambda: True)
+
+    def fake_version(name):
+        if name == "earthaccess":
+            return "0.14.0"
+        if name == "pandas":
+            return "2.2.0"
+        raise venv_manager.importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(venv_manager.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        venv_manager,
+        "_probe_earthaccess_in_venv",
+        lambda: (False, "ImportError: cannot import name foo"),
+    )
+
+    result = venv_manager.check_dependencies()
+    assert len(result) == 4
+    all_ok, missing, installed, broken = result
+
+    assert all_ok is False
+    assert ("geopandas", "") in missing
+    assert ("pandas", "2.2.0") in installed
+    assert any(name == "earthaccess" for name, _, _ in broken)

--- a/tests/test_venv_manager.py
+++ b/tests/test_venv_manager.py
@@ -1,10 +1,4 @@
-"""Tests for ``nasa_earthdata.core.venv_manager`` error classification.
-
-These tests do NOT exercise a real install. They monkey-patch the
-helpers used by ``import_earthaccess`` so we can assert the right
-classification (genuinely missing vs. installed-but-broken) without
-fabricating a working venv.
-"""
+"""Tests for ``nasa_earthdata.core.venv_manager`` import helpers."""
 
 import builtins
 import sys
@@ -38,41 +32,42 @@ def force_earthaccess_import_failure(monkeypatch):
     yield
 
 
-def test_import_earthaccess_classifies_missing_dist_info(
+def test_import_earthaccess_reports_missing_package(
     force_earthaccess_import_failure, monkeypatch
 ):
-    """When no dist-info is present, raise EarthaccessNotInstalledError."""
-    monkeypatch.setattr(venv_manager, "_earthaccess_dist_info_present", lambda: False)
+    """When metadata is missing, report that earthaccess is not installed."""
 
-    with pytest.raises(venv_manager.EarthaccessNotInstalledError) as exc_info:
+    def missing_version(name):
+        raise venv_manager.importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(venv_manager.importlib.metadata, "version", missing_version)
+
+    with pytest.raises(ImportError) as exc_info:
         venv_manager.import_earthaccess()
 
-    assert "not installed" in exc_info.value.user_message.lower()
-    # Inherits from ImportError so generic handlers still catch it.
-    assert isinstance(exc_info.value, ImportError)
+    assert "not installed" in str(exc_info.value).lower()
 
 
-def test_import_earthaccess_classifies_broken_install(
+def test_import_earthaccess_reports_broken_install(
     force_earthaccess_import_failure, monkeypatch
 ):
-    """When dist-info is present but import fails, raise EarthaccessImportError."""
-    monkeypatch.setattr(venv_manager, "_earthaccess_dist_info_present", lambda: True)
-    # Avoid touching subprocess/QGIS log during the test.
+    """When metadata exists but import fails, report the import error."""
     monkeypatch.setattr(
-        venv_manager, "_log_earthaccess_import_failure", lambda exc: None
+        venv_manager.importlib.metadata, "version", lambda name: "0.14.0"
     )
+    monkeypatch.setattr(venv_manager, "_log", lambda *args, **kwargs: None)
 
-    with pytest.raises(venv_manager.EarthaccessImportError) as exc_info:
+    with pytest.raises(ImportError) as exc_info:
         venv_manager.import_earthaccess()
 
-    assert "failed to import" in exc_info.value.user_message.lower()
-    assert isinstance(exc_info.value, ImportError)
-    assert exc_info.value.original is not None
+    message = str(exc_info.value).lower()
+    assert "0.14.0" in message
+    assert "failed to import" in message
+    assert "simulated: earthaccess fails to import" in message
 
 
-def test_check_dependencies_returns_four_tuple(monkeypatch):
-    """``check_dependencies`` must return (all_ok, missing, installed, broken)."""
-    # Force the metadata lookups and probe to deterministic values.
+def test_check_dependencies_returns_three_tuple(monkeypatch):
+    """``check_dependencies`` returns (all_ok, missing, installed)."""
     monkeypatch.setattr(venv_manager, "ensure_venv_packages_available", lambda: True)
 
     def fake_version(name):
@@ -83,17 +78,12 @@ def test_check_dependencies_returns_four_tuple(monkeypatch):
         raise venv_manager.importlib.metadata.PackageNotFoundError(name)
 
     monkeypatch.setattr(venv_manager.importlib.metadata, "version", fake_version)
-    monkeypatch.setattr(
-        venv_manager,
-        "_probe_earthaccess_in_venv",
-        lambda: (False, "ImportError: cannot import name foo"),
-    )
 
     result = venv_manager.check_dependencies()
-    assert len(result) == 4
-    all_ok, missing, installed, broken = result
+    assert len(result) == 3
+    all_ok, missing, installed = result
 
     assert all_ok is False
     assert ("geopandas", "") in missing
+    assert ("earthaccess", "0.14.0") in installed
     assert ("pandas", "2.2.0") in installed
-    assert any(name == "earthaccess" for name, _, _ in broken)


### PR DESCRIPTION
## Summary
- Fixes #26: "Test Credentials" used to claim *earthaccess package not installed* whenever `import earthaccess` raised `ImportError`, even when the Dependencies tab clearly showed earthaccess as installed. The two paths used different checks — the tab reads `importlib.metadata.version()` (text only), while the login path runs the real import machinery and trips on ABI mismatches and partial transitive installs.
- New `import_earthaccess()` helper classifies the failure (genuinely missing vs. installed-but-broken) and logs diagnostics — QGIS Python version, venv Python version, traceback, site-packages path — to the QGIS log. The status label now shows the real reason rather than a fixed lie.
- `check_dependencies()` now also runs a venv-Python subprocess import probe and returns a fourth `broken` list, so the Dependencies tab stops marking a package green when it cannot actually be imported. UI shows `vX.Y.Z (broken - reinstall)` in red and the install button switches to *Reinstall Dependencies*.
- All four `import earthaccess` callsites (settings login + three earthdata_dock workers) now go through the helper.
- Added `tests/test_venv_manager.py` covering both classification paths and the new 4-tuple return.

## Test plan
- [x] `pytest tests/` — 15 passed
- [x] `pre-commit run --all-files` — Bandit, black, codespell all pass
- [x] Smoke test: `check_dependencies()` returns the 4-tuple and falls through cleanly when no venv is present (so users with system-installed earthaccess still see green)
- [ ] Manual: install plugin in a QGIS where the venv Python minor differs from QGIS's Python and confirm the Test Credentials label now shows the real ImportError plus a pointer to the Log Messages panel