### PR TITLE
Add GeoAgent-powered AI Assistant dock

### DIFF
--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -27,6 +27,17 @@ REQUIRED_PACKAGES = [
     ("geopandas", ""),
 ]
 
+ASSISTANT_PACKAGES = [
+    ("geoagent", "[providers]>=1.0.0"),
+    ("openai", ">=1.0"),
+    ("anthropic", ">=0.40"),
+    ("google-genai", ">=1.0"),
+    ("ollama", ">=0.3"),
+    ("strands-agents", "[litellm]>=1.37"),
+]
+
+INSTALL_PACKAGES = REQUIRED_PACKAGES + ASSISTANT_PACKAGES
+
 
 def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
@@ -497,7 +508,7 @@ def install_dependencies(venv_dir=None, progress_callback=None, cancel_check=Non
     # Build the full list of package specs for batch installation
     pkg_specs = []
     pkg_names = []
-    for package_name, version_spec in REQUIRED_PACKAGES:
+    for package_name, version_spec in INSTALL_PACKAGES:
         pkg_spec = f"{package_name}{version_spec}" if version_spec else package_name
         pkg_specs.append(pkg_spec)
         pkg_names.append(package_name)
@@ -506,7 +517,7 @@ def install_dependencies(venv_dir=None, progress_callback=None, cancel_check=Non
         return False, "Installation cancelled."
 
     # Scale timeout with number of packages (600s per package)
-    total = len(REQUIRED_PACKAGES)
+    total = len(INSTALL_PACKAGES)
     timeout = 600 * total
 
     if progress_callback:
@@ -1042,7 +1053,7 @@ def get_venv_status():
     return True, "Virtual environment ready"
 
 
-def check_dependencies():
+def check_dependencies(include_assistant=False):
     """Check if all required packages are installed.
 
     Attempts to use importlib.metadata after ensuring venv packages
@@ -1059,7 +1070,8 @@ def check_dependencies():
     missing = []
     installed = []
 
-    for package_name, version_spec in REQUIRED_PACKAGES:
+    packages = INSTALL_PACKAGES if include_assistant else REQUIRED_PACKAGES
+    for package_name, version_spec in packages:
         try:
             version = importlib.metadata.version(package_name)
             installed.append((package_name, version))
@@ -1068,6 +1080,12 @@ def check_dependencies():
 
     all_ok = len(missing) == 0
     return all_ok, missing, installed
+
+
+def assistant_dependencies_met():
+    """Return True when GeoAgent and provider packages are installed."""
+    all_ok, _missing, _installed = check_dependencies(include_assistant=True)
+    return all_ok
 
 
 # ---------------------------------------------------------------------------

--- a/nasa_earthdata/dialogs/chat_dock.py
+++ b/nasa_earthdata/dialogs/chat_dock.py
@@ -1,0 +1,696 @@
+"""Dockable GeoAgent chat interface for the NASA Earthdata plugin."""
+
+import os
+import html
+import re
+import time
+import traceback
+
+from qgis.PyQt.QtCore import Qt, QSettings, QThread, QTimer, pyqtSignal
+from qgis.PyQt.QtGui import QGuiApplication, QTextCursor
+from qgis.PyQt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDockWidget,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QPlainTextEdit,
+    QSizePolicy,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+SETTINGS_PREFIX = "NASAEarthdata/"
+DEFAULT_MODELS = {
+    "bedrock": "us.anthropic.claude-sonnet-4-6",
+    "openai": "gpt-5.5",
+    "anthropic": "claude-sonnet-4-6",
+    "gemini": "gemini-3.1-pro-preview",
+    "ollama": "qwen3.5:4b",
+    "litellm": "openai/gpt-5.5",
+}
+PROVIDERS = ["bedrock", "openai", "anthropic", "gemini", "ollama", "litellm"]
+MAX_CONTEXT_MESSAGES = 12
+MAX_CONTEXT_CHARS = 12000
+SAMPLE_PROMPTS = [
+    "Search the NASA Earthdata catalog for MODIS fire products.",
+    "Find Landsat surface reflectance datasets for the current map extent.",
+    "Search GEDI granules in the current map extent for the last year.",
+    "Display footprints for the most recent NASA Earthdata search.",
+    "Find COG or GeoTIFF links in the latest search results that can be loaded into QGIS.",
+    "Open the NASA Earthdata search panel.",
+    "Summarize the current QGIS project layers and suggest useful Earthdata searches.",
+]
+
+
+def _setting(settings, key, default="", value_type=str):
+    """Read a plugin setting value."""
+    return settings.value(f"{SETTINGS_PREFIX}{key}", default, type=value_type)
+
+
+def _apply_environment_from_settings(settings):
+    """Apply provider credentials from QSettings to the current QGIS process."""
+    env_map = {
+        "openai_api_key": "OPENAI_API_KEY",
+        "anthropic_api_key": "ANTHROPIC_API_KEY",
+        "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "aws_region": "AWS_REGION",
+        "ollama_host": "OLLAMA_HOST",
+        "litellm_api_key": "LITELLM_API_KEY",
+        "litellm_base_url": "LITELLM_BASE_URL",
+        "username": "EARTHDATA_USERNAME",
+        "password": "EARTHDATA_PASSWORD",  # nosec B105 - env var name, not a password
+    }
+    for key, env_names in env_map.items():
+        value = _setting(settings, key, "").strip()
+        if value:
+            if isinstance(env_names, str):
+                env_names = (env_names,)
+            for env_name in env_names:
+                os.environ[env_name] = value
+
+
+def _qt_value(enum_name, member_name):
+    """Return a Qt enum member across PyQt enum API variants."""
+    container = getattr(Qt, enum_name, Qt)
+    return getattr(container, member_name)
+
+
+def _enum_value(cls, enum_name, member_name):
+    """Return an enum member from either scoped or legacy Qt APIs."""
+    container = getattr(cls, enum_name, cls)
+    return getattr(container, member_name)
+
+
+def _plain_text_to_html(text):
+    """Convert plain text to basic HTML."""
+    return html.escape(text).replace("\n", "<br>")
+
+
+def _inline_markdown_to_html(text):
+    """Convert inline Markdown spans to HTML."""
+    text = html.escape(text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", text)
+    return text
+
+
+def _markdown_to_basic_html(markdown):
+    """Small fallback renderer for common Markdown when Qt lacks setMarkdown."""
+    lines = markdown.splitlines()
+    html_lines = []
+    in_ul = False
+    in_ol = False
+    in_code = False
+    code_lines = []
+
+    def close_lists():
+        """Close any open HTML list elements."""
+        nonlocal in_ul, in_ol
+        if in_ul:
+            html_lines.append("</ul>")
+            in_ul = False
+        if in_ol:
+            html_lines.append("</ol>")
+            in_ol = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if in_code:
+                html_lines.append(
+                    f"<pre><code>{html.escape(chr(10).join(code_lines))}</code></pre>"
+                )
+                code_lines = []
+                in_code = False
+            else:
+                close_lists()
+                in_code = True
+            continue
+        if in_code:
+            code_lines.append(line)
+            continue
+
+        if not stripped:
+            close_lists()
+            html_lines.append("")
+            continue
+
+        heading = re.match(r"^(#{1,3})\s+(.+)$", stripped)
+        if heading:
+            close_lists()
+            level = len(heading.group(1))
+            html_lines.append(
+                f"<h{level}>{_inline_markdown_to_html(heading.group(2))}</h{level}>"
+            )
+            continue
+
+        bullet = re.match(r"^[-*]\s+(.+)$", stripped)
+        if bullet:
+            if in_ol:
+                html_lines.append("</ol>")
+                in_ol = False
+            if not in_ul:
+                html_lines.append("<ul>")
+                in_ul = True
+            html_lines.append(f"<li>{_inline_markdown_to_html(bullet.group(1))}</li>")
+            continue
+
+        numbered = re.match(r"^\d+\.\s+(.+)$", stripped)
+        if numbered:
+            if in_ul:
+                html_lines.append("</ul>")
+                in_ul = False
+            if not in_ol:
+                html_lines.append("<ol>")
+                in_ol = True
+            html_lines.append(f"<li>{_inline_markdown_to_html(numbered.group(1))}</li>")
+            continue
+
+        close_lists()
+        html_lines.append(f"<p>{_inline_markdown_to_html(stripped)}</p>")
+
+    if in_code:
+        html_lines.append(
+            f"<pre><code>{html.escape(chr(10).join(code_lines))}</code></pre>"
+        )
+    close_lists()
+    return "\n".join(html_lines)
+
+
+class PromptTextEdit(QPlainTextEdit):
+    """Prompt editor with chat-friendly keyboard shortcuts."""
+
+    send_requested = pyqtSignal()
+    previous_requested = pyqtSignal()
+    next_requested = pyqtSignal()
+
+    def keyPressEvent(self, event):
+        """Handle send and prompt-history keyboard shortcuts."""
+        key = event.key()
+        modifiers = event.modifiers()
+        control = _qt_value("KeyboardModifier", "ControlModifier")
+        key_return = _qt_value("Key", "Key_Return")
+        key_enter = _qt_value("Key", "Key_Enter")
+        key_up = _qt_value("Key", "Key_Up")
+        key_down = _qt_value("Key", "Key_Down")
+
+        if modifiers & control and key in (key_return, key_enter):
+            self.send_requested.emit()
+            event.accept()
+            return
+        if key == key_up and not modifiers:
+            self.previous_requested.emit()
+            event.accept()
+            return
+        if key == key_down and not modifiers:
+            self.next_requested.emit()
+            event.accept()
+            return
+
+        super().keyPressEvent(event)
+
+
+class ChatWorker(QThread):
+    """Run GeoAgent chat without blocking the QGIS UI."""
+
+    finished = pyqtSignal(dict)
+
+    def __init__(
+        self,
+        iface,
+        plugin,
+        prompt,
+        provider,
+        model_id,
+        fast,
+        max_tokens,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.iface = iface
+        self.plugin = plugin
+        self.prompt = prompt
+        self.provider = provider
+        self.model_id = model_id or None
+        self.fast = fast
+        self.max_tokens = max_tokens
+
+    def run(self):
+        """Create a GeoAgent NASA Earthdata agent and execute one chat turn."""
+        try:
+            from ..core.venv_manager import ensure_venv_packages_available
+
+            ensure_venv_packages_available()
+            from geoagent import GeoAgentConfig, auto_approve_all
+
+            try:
+                from qgis.core import QgsProject
+
+                project = QgsProject.instance()
+            except Exception:
+                project = None
+
+            config = GeoAgentConfig(
+                provider=self.provider,
+                model=self.model_id,
+                max_tokens=self.max_tokens,
+            )
+            try:
+                from geoagent import for_nasa_earthdata
+
+                agent = for_nasa_earthdata(
+                    self.iface,
+                    project=project,
+                    plugin=self.plugin,
+                    config=config,
+                    fast=self.fast,
+                    confirm=auto_approve_all,
+                )
+            except ImportError:
+                from geoagent import for_qgis
+                from geoagent.tools.nasa_earthdata import earthdata_tools
+
+                try:
+                    extra_tools = earthdata_tools(
+                        self.iface,
+                        project=project,
+                        plugin=self.plugin,
+                    )
+                except TypeError:
+                    extra_tools = earthdata_tools()
+
+                agent = for_qgis(
+                    self.iface,
+                    project=project,
+                    config=config,
+                    fast=self.fast,
+                    extra_tools=extra_tools,
+                    confirm=auto_approve_all,
+                )
+            response = agent.chat(self.prompt)
+
+            self.finished.emit(
+                {
+                    "success": bool(response.success),
+                    "answer": response.answer_text or "",
+                    "error": response.error_message or "",
+                    "tools": ", ".join(response.executed_tools or []),
+                    "cancelled": ", ".join(response.cancelled_tools or []),
+                    "elapsed": f"{response.execution_time:.2f}s",
+                }
+            )
+        except Exception as exc:
+            self.finished.emit(
+                {
+                    "success": False,
+                    "answer": "",
+                    "error": f"{exc}\n\n{traceback.format_exc()}",
+                    "tools": "",
+                    "cancelled": "",
+                    "elapsed": "",
+                }
+            )
+
+
+class ChatDockWidget(QDockWidget):
+    """Dock widget that sends user prompts to a GeoAgent QGIS agent."""
+
+    def __init__(self, iface, plugin=None, parent=None):
+        super().__init__("NASA Earthdata AI Assistant", parent)
+        self.iface = iface
+        self.plugin = plugin
+        self.settings = QSettings()
+        self._worker = None
+        self._prompt_history = []
+        self._history_index = None
+        self._messages = []
+        self._last_assistant_markdown = ""
+        self._status_started_at = None
+        self._status_base_text = "Running"
+        self._status_frame = 0
+        self._status_timer = QTimer(self)
+        self._status_timer.setInterval(500)
+        self._status_timer.timeout.connect(self._update_running_status)
+
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
+        self.setMinimumWidth(280)
+
+        self._setup_ui()
+        self._load_settings()
+
+    def _setup_ui(self):
+        """Build the chat dock widgets and signal connections."""
+        main_widget = QWidget()
+        self.setWidget(main_widget)
+
+        layout = QVBoxLayout(main_widget)
+        layout.setSpacing(8)
+
+        model_group = QGroupBox("Model")
+        model_layout = QFormLayout(model_group)
+
+        self.provider_combo = QComboBox()
+        self.provider_combo.addItems(PROVIDERS)
+        self.provider_combo.setMinimumContentsLength(10)
+        self.provider_combo.setSizeAdjustPolicy(
+            _enum_value(
+                QComboBox,
+                "SizeAdjustPolicy",
+                "AdjustToMinimumContentsLengthWithIcon",
+            )
+        )
+        self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
+        model_layout.addRow("Provider:", self.provider_combo)
+
+        self.model_input = QLineEdit()
+        self.model_input.setPlaceholderText("Use provider default")
+        model_layout.addRow("Model:", self.model_input)
+
+        self.fast_check = QCheckBox("Fast mode")
+        model_layout.addRow("", self.fast_check)
+
+        layout.addWidget(model_group)
+
+        sample_layout = QHBoxLayout()
+        self.sample_combo = QComboBox()
+        self.sample_combo.addItem("Sample prompts...")
+        self.sample_combo.addItems(SAMPLE_PROMPTS)
+        self.sample_combo.setMinimumContentsLength(22)
+        self.sample_combo.setSizeAdjustPolicy(
+            _enum_value(
+                QComboBox,
+                "SizeAdjustPolicy",
+                "AdjustToMinimumContentsLengthWithIcon",
+            )
+        )
+        self.sample_combo.setSizePolicy(
+            _enum_value(QSizePolicy, "Policy", "Ignored"),
+            _enum_value(QSizePolicy, "Policy", "Fixed"),
+        )
+        self.sample_combo.currentTextChanged.connect(self._select_sample_prompt)
+        sample_layout.addWidget(self.sample_combo, 1)
+        layout.addLayout(sample_layout)
+
+        self.transcript = QTextEdit()
+        self.transcript.setReadOnly(True)
+        self.transcript.setAcceptRichText(True)
+        self.transcript.setPlaceholderText("Conversation will appear here.")
+        layout.addWidget(self.transcript, 1)
+
+        self.prompt_input = PromptTextEdit()
+        self.prompt_input.setPlaceholderText(
+            "Ask GeoAgent to search, inspect, or load NASA Earthdata."
+        )
+        self.prompt_input.setMaximumHeight(90)
+        self.prompt_input.send_requested.connect(self._send_prompt)
+        self.prompt_input.previous_requested.connect(self._previous_prompt)
+        self.prompt_input.next_requested.connect(self._next_prompt)
+        layout.addWidget(self.prompt_input)
+
+        primary_button_layout = QHBoxLayout()
+        self.send_btn = QPushButton("Send")
+        self.send_btn.clicked.connect(self._send_prompt)
+        primary_button_layout.addWidget(self.send_btn)
+
+        self.clear_btn = QPushButton("Clear")
+        self.clear_btn.clicked.connect(self._clear_transcript)
+        primary_button_layout.addWidget(self.clear_btn)
+
+        self.copy_md_btn = QPushButton("Copy Markdown")
+        self.copy_md_btn.setEnabled(False)
+        self.copy_md_btn.clicked.connect(self._copy_latest_markdown)
+        primary_button_layout.addWidget(self.copy_md_btn)
+        layout.addLayout(primary_button_layout)
+
+        self.status_label = QLabel("Ready. Ctrl+Enter sends. Up/Down cycles prompts.")
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+        layout.addWidget(self.status_label)
+
+    def _load_settings(self):
+        """Load persisted model settings into the dock controls."""
+        provider = _setting(self.settings, "provider", "openai")
+        index = self.provider_combo.findText(provider)
+        self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
+
+        model = _setting(self.settings, "model", "")
+        if not model:
+            model = DEFAULT_MODELS.get(self.provider_combo.currentText(), "")
+        self.model_input.setText(model)
+
+        self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
+
+    def _save_model_settings(self):
+        """Persist the selected provider, model, and fast-mode setting."""
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}provider", self.provider_combo.currentText()
+        )
+        self.settings.setValue(f"{SETTINGS_PREFIX}model", self.model_input.text())
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+
+    def _on_provider_changed(self, provider):
+        """Update the model field when the provider changes."""
+        self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
+
+    def _send_prompt(self):
+        """Start a chat request for the current prompt."""
+        prompt = self.prompt_input.toPlainText().strip()
+        if not prompt:
+            return
+        if self._worker is not None:
+            QMessageBox.information(
+                self,
+                "NASA Earthdata",
+                "A request is already running. Wait for it to finish first.",
+            )
+            return
+
+        self._save_model_settings()
+        self._record_prompt(prompt)
+        _apply_environment_from_settings(self.settings)
+
+        provider = self.provider_combo.currentText()
+        model_id = self.model_input.text().strip()
+        fast = self.fast_check.isChecked()
+        max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
+        prompt_with_context = self._build_prompt_with_context(prompt)
+
+        self._append_message("You", prompt, markdown=False)
+        self.prompt_input.clear()
+        self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
+        self._start_running_status("Running GeoAgent")
+        self.send_btn.setEnabled(False)
+
+        self._worker = ChatWorker(
+            self.iface,
+            self.plugin,
+            prompt_with_context,
+            provider,
+            model_id,
+            fast,
+            max_tokens,
+            self,
+        )
+        self._worker.finished.connect(self._on_worker_finished)
+        self._worker.start()
+
+    def _build_prompt_with_context(self, prompt):
+        """Include recent chat transcript so follow-up turns have context."""
+        if not self._messages:
+            return prompt
+
+        history_lines = []
+        for msg in self._messages[-MAX_CONTEXT_MESSAGES:]:
+            body = msg.get("body", "").strip()
+            if not body:
+                continue
+            role = "User" if msg.get("sender") == "You" else "Assistant"
+            history_lines.append(f"{role}: {body}")
+
+        if not history_lines:
+            return prompt
+
+        history = "\n\n".join(history_lines)
+        if len(history) > MAX_CONTEXT_CHARS:
+            history = history[-MAX_CONTEXT_CHARS:]
+            history = f"[Earlier history truncated]\n{history}"
+
+        return (
+            "Use the recent conversation history for context. The current user "
+            "request is the authoritative request to answer now.\n\n"
+            f"Recent conversation:\n{history}\n\n"
+            f"Current user request:\n{prompt}"
+        )
+
+    def _select_sample_prompt(self, prompt):
+        """Copy the selected sample prompt into the editor."""
+        if prompt and prompt != "Sample prompts...":
+            self.prompt_input.setPlainText(prompt)
+            self.prompt_input.setFocus()
+
+    def _record_prompt(self, prompt):
+        """Store a submitted prompt in history."""
+        if not self._prompt_history or self._prompt_history[-1] != prompt:
+            self._prompt_history.append(prompt)
+        self._history_index = None
+
+    def _previous_prompt(self):
+        """Load the previous prompt from history."""
+        if not self._prompt_history:
+            return
+        if self._history_index is None:
+            self._history_index = len(self._prompt_history) - 1
+        else:
+            self._history_index = (self._history_index - 1) % len(self._prompt_history)
+        self._set_prompt_from_history()
+
+    def _next_prompt(self):
+        """Load the next prompt from history."""
+        if not self._prompt_history:
+            return
+        if self._history_index is None:
+            self._history_index = 0
+        else:
+            self._history_index = (self._history_index + 1) % len(self._prompt_history)
+        self._set_prompt_from_history()
+
+    def _set_prompt_from_history(self):
+        """Set prompt from history."""
+        self.prompt_input.setPlainText(self._prompt_history[self._history_index])
+        self.prompt_input.setFocus()
+
+    def _on_worker_finished(self, result):
+        """Render the completed chat worker result."""
+        self._stop_running_status()
+        if result.get("success"):
+            answer = result.get("answer") or "(No text response.)"
+            details = []
+            if result.get("tools"):
+                details.append(f"Tools: {result['tools']}")
+            if result.get("elapsed"):
+                details.append(f"Elapsed: {result['elapsed']}")
+            if details:
+                answer = f"{answer}\n\n" + "\n".join(details)
+            self._append_message("GeoAgent", answer, markdown=True)
+            self.status_label.setText("Ready")
+            self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+        else:
+            error = result.get("error") or "Unknown error"
+            cancelled = result.get("cancelled")
+            if cancelled:
+                error = f"{error}\nCancelled tools: {cancelled}"
+            self._append_message("GeoAgent", f"Error:\n{error}", markdown=False)
+            self.status_label.setText("Error")
+            self.status_label.setStyleSheet("color: red; font-size: 10px;")
+
+        self.send_btn.setEnabled(True)
+        self._worker = None
+
+    def _start_running_status(self, base_text):
+        """Start or update the animated status text."""
+        self._status_base_text = base_text
+        if self._status_started_at is None:
+            self._status_started_at = time.monotonic()
+            self._status_frame = 0
+        if not self._status_timer.isActive():
+            self._status_timer.start()
+        self._update_running_status()
+
+    def _stop_running_status(self):
+        """Stop the animated status text."""
+        if self._status_timer.isActive():
+            self._status_timer.stop()
+        self._status_started_at = None
+        self._status_frame = 0
+
+    def _update_running_status(self):
+        """Refresh the animated status text."""
+        if self._status_started_at is None:
+            return
+        elapsed = int(time.monotonic() - self._status_started_at)
+        spinner = ("-", "\\", "|", "/")[self._status_frame % 4]
+        self._status_frame += 1
+        dots = "." * (self._status_frame % 4)
+        if elapsed >= 30:
+            suffix = "large QGIS operations can take a while"
+        elif elapsed >= 10:
+            suffix = "running tools and waiting for the model"
+        else:
+            suffix = "working"
+        self.status_label.setText(
+            f"{spinner} {self._status_base_text}{dots} {elapsed}s - {suffix}"
+        )
+
+    def _append_message(self, sender, message, markdown=False):
+        """Append a chat message and refresh the transcript."""
+        body = message.strip()
+        self._messages.append({"sender": sender, "body": body, "markdown": markdown})
+        if markdown:
+            self._last_assistant_markdown = body
+            self.copy_md_btn.setEnabled(True)
+        self._render_transcript()
+
+    def _render_transcript(self):
+        """Render the stored chat messages as HTML."""
+        blocks = []
+        for msg in self._messages:
+            sender = html.escape(msg["sender"])
+            if msg["markdown"]:
+                body = _markdown_to_basic_html(msg["body"])
+            else:
+                body = f"<p>{_plain_text_to_html(msg['body'])}</p>"
+            blocks.append(
+                "<div style='margin-bottom: 12px;'>"
+                f"<p style='font-weight: 600; margin-bottom: 4px;'>{sender}</p>"
+                f"{body}"
+                "</div>"
+            )
+        self.transcript.setHtml("\n".join(blocks))
+        end_cursor = getattr(getattr(QTextCursor, "MoveOperation", QTextCursor), "End")
+        self.transcript.moveCursor(end_cursor)
+
+    def _copy_latest_markdown(self):
+        """Copy the latest assistant Markdown response to the clipboard."""
+        if not self._last_assistant_markdown:
+            return
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(self._last_assistant_markdown)
+            self.status_label.setText("Copied latest response as Markdown.")
+            self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
+    def _clear_transcript(self):
+        """Clear all rendered chat messages."""
+        self._messages = []
+        self._last_assistant_markdown = ""
+        self.copy_md_btn.setEnabled(False)
+        self.transcript.clear()
+
+    def _shutdown_running_state(self):
+        """Stop the animated status timer when the dock is dismissed."""
+        try:
+            self._stop_running_status()
+        except Exception:
+            pass  # nosec B110 - best-effort cleanup on dock dismissal
+
+    def hideEvent(self, event):
+        """Stop the animated status timer when the dock is hidden."""
+        self._shutdown_running_state()
+        super().hideEvent(event)
+
+    def closeEvent(self, event):
+        """Stop the animated status timer when the dock is closed."""
+        self._shutdown_running_state()
+        super().closeEvent(event)

--- a/nasa_earthdata/dialogs/chat_dock.py
+++ b/nasa_earthdata/dialogs/chat_dock.py
@@ -685,12 +685,35 @@ class ChatDockWidget(QDockWidget):
         except Exception:
             pass  # nosec B110 - best-effort cleanup on dock dismissal
 
+    def shutdown(self):
+        """Stop the status timer and wait for any in-flight chat worker.
+
+        Called from the plugin unload path and ``closeEvent`` so the dock
+        does not get torn down while a ``QThread`` is still running, which
+        would crash QGIS with "QThread: Destroyed while thread is still
+        running".
+        """
+        self._shutdown_running_state()
+        worker = self._worker
+        if worker is None:
+            return
+        try:
+            worker.finished.disconnect(self._on_worker_finished)
+        except (TypeError, RuntimeError):
+            pass  # nosec B110 - signal may already be disconnected
+        try:
+            if worker.isRunning():
+                worker.wait(5000)
+        except RuntimeError:
+            pass  # nosec B110 - worker C++ object already deleted
+        self._worker = None
+
     def hideEvent(self, event):
         """Stop the animated status timer when the dock is hidden."""
         self._shutdown_running_state()
         super().hideEvent(event)
 
     def closeEvent(self, event):
-        """Stop the animated status timer when the dock is closed."""
-        self._shutdown_running_state()
+        """Stop the animated status timer and any worker when closed."""
+        self.shutdown()
         super().closeEvent(event)

--- a/nasa_earthdata/dialogs/settings_dock.py
+++ b/nasa_earthdata/dialogs/settings_dock.py
@@ -411,11 +411,23 @@ class SettingsDockWidget(QDockWidget):
         status_group = QGroupBox("Package Status")
         self._deps_status_layout = QFormLayout(status_group)
 
-        # Create status labels for each package
+        # Create status labels for each package, grouped by required vs optional.
         self._deps_labels = {}
-        from ..core.venv_manager import INSTALL_PACKAGES
+        from ..core.venv_manager import ASSISTANT_PACKAGES, REQUIRED_PACKAGES
 
-        for package_name, _version_spec in INSTALL_PACKAGES:
+        required_header = QLabel("Required (NASA Earthdata core):")
+        required_header.setStyleSheet("font-weight: bold;")
+        self._deps_status_layout.addRow(required_header)
+        for package_name, _version_spec in REQUIRED_PACKAGES:
+            label = QLabel("Checking...")
+            label.setStyleSheet("color: gray;")
+            self._deps_labels[package_name] = label
+            self._deps_status_layout.addRow(f"{package_name}:", label)
+
+        assistant_header = QLabel("AI Assistant (optional):")
+        assistant_header.setStyleSheet("font-weight: bold; margin-top: 6px;")
+        self._deps_status_layout.addRow(assistant_header)
+        for package_name, _version_spec in ASSISTANT_PACKAGES:
             label = QLabel("Checking...")
             label.setStyleSheet("color: gray;")
             self._deps_labels[package_name] = label
@@ -463,6 +475,7 @@ class SettingsDockWidget(QDockWidget):
         """Refresh the dependency status display."""
         from ..core.venv_manager import check_dependencies
 
+        required_ok, _, _ = check_dependencies(include_assistant=False)
         all_ok, missing, installed = check_dependencies(include_assistant=True)
 
         for package_name, version in installed:
@@ -480,6 +493,10 @@ class SettingsDockWidget(QDockWidget):
         self.install_deps_btn.setEnabled(not all_ok)
         if all_ok:
             self.install_deps_btn.setText("All Dependencies Installed")
+        elif required_ok:
+            self.install_deps_btn.setText(
+                f"Install AI Assistant Packages ({len(missing)} missing)"
+            )
         else:
             self.install_deps_btn.setText(
                 f"Install Dependencies ({len(missing)} missing)"

--- a/nasa_earthdata/dialogs/settings_dock.py
+++ b/nasa_earthdata/dialogs/settings_dock.py
@@ -30,6 +30,14 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtGui import QFont
 
+from .chat_dock import DEFAULT_MODELS, PROVIDERS
+
+
+def _enum_value(cls, enum_name, member_name):
+    """Return an enum member from either scoped or legacy Qt APIs."""
+    container = getattr(cls, enum_name, cls)
+    return getattr(container, member_name)
+
 
 class SettingsDockWidget(QDockWidget):
     """A settings panel for configuring NASA Earthdata plugin options."""
@@ -89,6 +97,10 @@ class SettingsDockWidget(QDockWidget):
         # Credentials tab
         credentials_tab = self._create_credentials_tab()
         self.tab_widget.addTab(credentials_tab, "Credentials")
+
+        # Model tab
+        model_tab = self._create_model_tab()
+        self.tab_widget.addTab(model_tab, "Model")
 
         # General settings tab
         general_tab = self._create_general_tab()
@@ -184,6 +196,87 @@ class SettingsDockWidget(QDockWidget):
 
         layout.addWidget(netrc_group)
 
+        layout.addStretch()
+        return widget
+
+    def _create_model_tab(self):
+        """Create the GeoAgent model provider and credential tab."""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        model_group = QGroupBox("GeoAgent Provider")
+        form = QFormLayout(model_group)
+
+        self.provider_combo = QComboBox()
+        self.provider_combo.addItems(PROVIDERS)
+        self.provider_combo.setMinimumContentsLength(10)
+        self.provider_combo.setSizeAdjustPolicy(
+            _enum_value(
+                QComboBox,
+                "SizeAdjustPolicy",
+                "AdjustToMinimumContentsLengthWithIcon",
+            )
+        )
+        self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
+        form.addRow("Provider:", self.provider_combo)
+
+        self.model_input = QLineEdit()
+        self.model_input.setPlaceholderText("Provider default")
+        form.addRow("Model:", self.model_input)
+
+        self.fast_check = QCheckBox("Use fast GeoAgent prompt")
+        form.addRow("", self.fast_check)
+
+        self.max_tokens_spin = QSpinBox()
+        self.max_tokens_spin.setRange(256, 32768)
+        self.max_tokens_spin.setValue(4096)
+        self.max_tokens_spin.setSingleStep(256)
+        form.addRow("Max tokens:", self.max_tokens_spin)
+
+        layout.addWidget(model_group)
+
+        credentials_group = QGroupBox("Provider Credentials and Hosts")
+        credentials_form = QFormLayout(credentials_group)
+
+        password_mode = getattr(getattr(QLineEdit, "EchoMode", QLineEdit), "Password")
+
+        self.openai_key_input = QLineEdit()
+        self.openai_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("OpenAI API key:", self.openai_key_input)
+
+        self.anthropic_key_input = QLineEdit()
+        self.anthropic_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("Anthropic API key:", self.anthropic_key_input)
+
+        self.gemini_key_input = QLineEdit()
+        self.gemini_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("Gemini API key:", self.gemini_key_input)
+
+        self.aws_region_input = QLineEdit()
+        self.aws_region_input.setPlaceholderText("e.g. us-east-1")
+        credentials_form.addRow("AWS region:", self.aws_region_input)
+
+        self.ollama_host_input = QLineEdit()
+        self.ollama_host_input.setPlaceholderText("http://127.0.0.1:11434")
+        credentials_form.addRow("Ollama host:", self.ollama_host_input)
+
+        self.litellm_key_input = QLineEdit()
+        self.litellm_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("LiteLLM API key:", self.litellm_key_input)
+
+        self.litellm_base_url_input = QLineEdit()
+        self.litellm_base_url_input.setPlaceholderText("https://proxy.example.com")
+        credentials_form.addRow("LiteLLM base URL:", self.litellm_base_url_input)
+
+        layout.addWidget(credentials_group)
+
+        note = QLabel(
+            "These values are used by the NASA Earthdata AI Assistant and saved "
+            "in QGIS settings."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet("font-size: 10px; color: gray;")
+        layout.addWidget(note)
         layout.addStretch()
         return widget
 
@@ -320,9 +413,9 @@ class SettingsDockWidget(QDockWidget):
 
         # Create status labels for each package
         self._deps_labels = {}
-        from ..core.venv_manager import REQUIRED_PACKAGES
+        from ..core.venv_manager import INSTALL_PACKAGES
 
-        for package_name, _version_spec in REQUIRED_PACKAGES:
+        for package_name, _version_spec in INSTALL_PACKAGES:
             label = QLabel("Checking...")
             label.setStyleSheet("color: gray;")
             self._deps_labels[package_name] = label
@@ -370,7 +463,7 @@ class SettingsDockWidget(QDockWidget):
         """Refresh the dependency status display."""
         from ..core.venv_manager import check_dependencies
 
-        all_ok, missing, installed = check_dependencies()
+        all_ok, missing, installed = check_dependencies(include_assistant=True)
 
         for package_name, version in installed:
             if package_name in self._deps_labels:
@@ -665,6 +758,10 @@ class SettingsDockWidget(QDockWidget):
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"Failed to clear cache:\n{e}")
 
+    def _on_provider_changed(self, provider):
+        """Update the model field when the provider changes."""
+        self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
+
     def _load_settings(self):
         """Load settings from QSettings."""
         # Credentials precedence: .netrc -> environment -> QSettings username
@@ -704,6 +801,44 @@ class SettingsDockWidget(QDockWidget):
                 "Using credentials from EARTHDATA_USERNAME/EARTHDATA_PASSWORD"
             )
             self.creds_status_label.setStyleSheet("color: green;")
+
+        # Model
+        provider = self.settings.value(
+            f"{self.SETTINGS_PREFIX}provider", "openai", type=str
+        )
+        index = self.provider_combo.findText(provider)
+        self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
+        model = self.settings.value(f"{self.SETTINGS_PREFIX}model", "", type=str)
+        self.model_input.setText(model or DEFAULT_MODELS.get(provider, ""))
+        self.fast_check.setChecked(
+            self.settings.value(f"{self.SETTINGS_PREFIX}fast_mode", False, type=bool)
+        )
+        self.max_tokens_spin.setValue(
+            self.settings.value(f"{self.SETTINGS_PREFIX}max_tokens", 4096, type=int)
+        )
+        self.openai_key_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}openai_api_key", "", type=str)
+        )
+        self.anthropic_key_input.setText(
+            self.settings.value(
+                f"{self.SETTINGS_PREFIX}anthropic_api_key", "", type=str
+            )
+        )
+        self.gemini_key_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}gemini_api_key", "", type=str)
+        )
+        self.aws_region_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}aws_region", "", type=str)
+        )
+        self.ollama_host_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}ollama_host", "", type=str)
+        )
+        self.litellm_key_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}litellm_api_key", "", type=str)
+        )
+        self.litellm_base_url_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}litellm_base_url", "", type=str)
+        )
 
         # General
         self.download_dir_input.setText(
@@ -776,6 +911,41 @@ class SettingsDockWidget(QDockWidget):
             )
             self.creds_status_label.setStyleSheet("color: orange;")
 
+        # Model
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}provider", self.provider_combo.currentText()
+        )
+        self.settings.setValue(f"{self.SETTINGS_PREFIX}model", self.model_input.text())
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}max_tokens", self.max_tokens_spin.value()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}openai_api_key", self.openai_key_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}anthropic_api_key",
+            self.anthropic_key_input.text(),
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}gemini_api_key", self.gemini_key_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}aws_region", self.aws_region_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}ollama_host", self.ollama_host_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}litellm_api_key", self.litellm_key_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}litellm_base_url",
+            self.litellm_base_url_input.text(),
+        )
+
         # General
         self.settings.setValue(
             f"{self.SETTINGS_PREFIX}download_dir", self.download_dir_input.text()
@@ -835,6 +1005,19 @@ class SettingsDockWidget(QDockWidget):
         # Credentials
         self.username_input.clear()
         self.password_input.clear()
+
+        # Model
+        self.provider_combo.setCurrentText("openai")
+        self.model_input.setText(DEFAULT_MODELS["openai"])
+        self.fast_check.setChecked(False)
+        self.max_tokens_spin.setValue(4096)
+        self.openai_key_input.clear()
+        self.anthropic_key_input.clear()
+        self.gemini_key_input.clear()
+        self.aws_region_input.clear()
+        self.ollama_host_input.clear()
+        self.litellm_key_input.clear()
+        self.litellm_base_url_input.clear()
 
         # General
         self.download_dir_input.clear()

--- a/nasa_earthdata/nasa_earthdata.py
+++ b/nasa_earthdata/nasa_earthdata.py
@@ -171,6 +171,12 @@ class NASAEarthdata:
             self._earthdata_dock = None
 
         if self._chat_dock:
+            shutdown = getattr(self._chat_dock, "shutdown", None)
+            if callable(shutdown):
+                try:
+                    shutdown()
+                except Exception:
+                    pass  # nosec B110 - best-effort worker shutdown on unload
             self.iface.removeDockWidget(self._chat_dock)
             self._chat_dock.deleteLater()
             self._chat_dock = None

--- a/nasa_earthdata/nasa_earthdata.py
+++ b/nasa_earthdata/nasa_earthdata.py
@@ -29,6 +29,7 @@ class NASAEarthdata:
 
         # Dock widgets (lazy loaded)
         self._earthdata_dock = None
+        self._chat_dock = None
         self._settings_dock = None
         self._deps_signal_connected = False
 
@@ -116,6 +117,15 @@ class NASAEarthdata:
             parent=self.iface.mainWindow(),
         )
 
+        self.chat_action = self.add_action(
+            main_icon,
+            "AI Assistant",
+            self.toggle_chat_dock,
+            status_tip="Ask GeoAgent to search and visualize NASA Earthdata",
+            checkable=True,
+            parent=self.iface.mainWindow(),
+        )
+
         # Add Settings Panel action (checkable for dock toggle)
         self.settings_action = self.add_action(
             settings_icon,
@@ -159,6 +169,11 @@ class NASAEarthdata:
             self.iface.removeDockWidget(self._earthdata_dock)
             self._earthdata_dock.deleteLater()
             self._earthdata_dock = None
+
+        if self._chat_dock:
+            self.iface.removeDockWidget(self._chat_dock)
+            self._chat_dock.deleteLater()
+            self._chat_dock = None
 
         if self._settings_dock:
             self.iface.removeDockWidget(self._settings_dock)
@@ -220,6 +235,57 @@ class NASAEarthdata:
     def _on_earthdata_visibility_changed(self, visible):
         """Handle NASA Earthdata dock visibility change."""
         self.earthdata_action.setChecked(visible)
+
+    def toggle_chat_dock(self):
+        """Toggle the NASA Earthdata AI assistant dock widget."""
+        if self._assistant_dependencies_missing():
+            self._open_settings_deps_tab()
+            self.chat_action.setChecked(False)
+            try:
+                self.iface.messageBar().pushWarning(
+                    "NASA Earthdata",
+                    "Install missing GeoAgent dependencies before opening the AI Assistant.",
+                )
+            except Exception:
+                pass  # nosec B110 - message bar failure should not block UI
+            return
+
+        if self._chat_dock is None:
+            try:
+                from .dialogs.chat_dock import ChatDockWidget
+
+                self._chat_dock = ChatDockWidget(
+                    self.iface, self, self.iface.mainWindow()
+                )
+                self._chat_dock.setObjectName("NASAEarthdataChatDock")
+                self._chat_dock.visibilityChanged.connect(
+                    self._on_chat_visibility_changed
+                )
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._chat_dock
+                )
+                self._chat_dock.show()
+                self._chat_dock.raise_()
+                return
+
+            except Exception as e:
+                QMessageBox.critical(
+                    self.iface.mainWindow(),
+                    "Error",
+                    f"Failed to create NASA Earthdata AI Assistant:\n{str(e)}",
+                )
+                self.chat_action.setChecked(False)
+                return
+
+        if self._chat_dock.isVisible():
+            self._chat_dock.hide()
+        else:
+            self._chat_dock.show()
+            self._chat_dock.raise_()
+
+    def _on_chat_visibility_changed(self, visible):
+        """Handle NASA Earthdata AI assistant dock visibility change."""
+        self.chat_action.setChecked(visible)
 
     def toggle_settings_dock(self):
         """Toggle the Settings dock widget visibility."""
@@ -301,6 +367,15 @@ class NASAEarthdata:
         except Exception:
             # Don't let dependency check errors prevent the dock from opening
             pass  # nosec B110 - dependency check is best-effort UX hint
+
+    def _assistant_dependencies_missing(self):
+        """Return True when GeoAgent assistant dependencies are unavailable."""
+        try:
+            from .core.venv_manager import assistant_dependencies_met
+
+            return not assistant_dependencies_met()
+        except Exception:
+            return True
 
     def _open_settings_deps_tab(self):
         """Open the Settings dock and switch to the Dependencies tab."""


### PR DESCRIPTION
## Summary
- New "AI Assistant" toolbar action that opens a dockable chat panel ([nasa_earthdata/dialogs/chat_dock.py](nasa_earthdata/dialogs/chat_dock.py)) where users ask GeoAgent to search NASA Earthdata, inspect layers, and load granules in plain language.
- Adds optional GeoAgent and provider packages (openai, anthropic, google-genai, ollama, strands-agents[litellm]) to the venv installer; required NASA Earthdata packages still install on their own and the assistant only opens once GeoAgent dependencies are present ([nasa_earthdata/core/venv_manager.py](nasa_earthdata/core/venv_manager.py)).
- New Model tab in the Settings dock to pick a provider/model, toggle fast mode, set max tokens, and save per-provider API keys / hosts ([nasa_earthdata/dialogs/settings_dock.py](nasa_earthdata/dialogs/settings_dock.py)).
- Wires the toolbar action, dock lifecycle, and dependency gating in the main plugin ([nasa_earthdata/nasa_earthdata.py](nasa_earthdata/nasa_earthdata.py)). If GeoAgent packages are missing, clicking the action opens the Settings Dependencies tab with a warning instead of failing.

## Test plan
- [ ] Load the plugin in QGIS 3.x (PyQt5) and confirm the "AI Assistant" action appears and toggles the dock.
- [ ] Load the plugin in QGIS 4 nightly (PyQt6) and confirm the dock and Settings Model tab render correctly.
- [ ] With GeoAgent dependencies missing, click the action and verify it opens the Settings Dependencies tab with a warning instead of crashing.
- [ ] Install dependencies via Settings, configure an OpenAI/Anthropic/Gemini key, and run a sample prompt end-to-end.
- [ ] Verify provider switch updates the default model and that credentials persist across QGIS restarts.