### PR TITLE
Fix macOS QGIS dependency installer

### DIFF
--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -11,7 +11,7 @@ import importlib.metadata
 import os
 import platform
 import shutil
-import subprocess  # nosec B404 - only invoked with hard-coded internal commands
+import subprocess  # nosec B404
 import sys
 import time
 from typing import Tuple, Optional, Callable, List
@@ -205,9 +205,25 @@ def _is_python_executable_name(path: str) -> bool:
     )
 
 
+def _is_macos_qgis_app_bundle_python(path: str) -> bool:
+    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    if not (platform.system() == "Darwin" or sys.platform == "darwin"):
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for idx, part in enumerate(parts):
+        lower = part.lower()
+        if not (lower.startswith("qgis") and lower.endswith(".app")):
+            continue
+        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+    return False
+
+
 def _python_candidate_matches_runtime(path: str) -> bool:
     """Return True when a candidate is executable and matches QGIS Python."""
     if not path or not os.path.isfile(path) or not _is_python_executable_name(path):
+        return False
+
+    if _is_macos_qgis_app_bundle_python(path):
         return False
     try:
         result = subprocess.run(  # nosec B603
@@ -425,11 +441,14 @@ def create_venv(venv_dir=None, progress_callback=None):
     if progress_callback:
         progress_callback(10, "Creating virtual environment...")
 
+    system_python = None
+    python_lookup_error = ""
     try:
         system_python = _get_system_python()
     except RuntimeError as exc:
-        return False, str(exc)
-    _log(f"Using Python: {system_python}")
+        python_lookup_error = str(exc)
+    if system_python:
+        _log(f"Using Python: {system_python}")
 
     from .uv_manager import uv_exists, get_uv_path
 
@@ -437,9 +456,15 @@ def create_venv(venv_dir=None, progress_callback=None):
 
     if use_uv:
         uv_path = get_uv_path()
-        cmd = [uv_path, "venv", "--python", system_python, venv_dir]
+        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        cmd = [uv_path, "venv"]
+        if system_python is None:
+            cmd.append("--managed-python")
+        cmd += ["--python", uv_python, venv_dir]
         _log("Creating venv with uv")
     else:
+        if system_python is None:
+            return False, python_lookup_error
         cmd = [system_python, "-m", "venv", venv_dir]
         _log("Creating venv with stdlib venv")
 
@@ -447,7 +472,7 @@ def create_venv(venv_dir=None, progress_callback=None):
         env = _get_clean_env_for_venv()
         kwargs = _get_subprocess_kwargs()
 
-        result = subprocess.run(  # nosec B603 - internal command list, shell=False
+        result = subprocess.run(  # nosec B603
             cmd,
             capture_output=True,
             text=True,
@@ -472,7 +497,7 @@ def create_venv(venv_dir=None, progress_callback=None):
                         "--upgrade",
                     ]
                     try:
-                        ensurepip_result = subprocess.run(  # nosec B603 - internal command list, shell=False
+                        ensurepip_result = subprocess.run(  # nosec B603
                             ensurepip_cmd,
                             capture_output=True,
                             text=True,
@@ -684,7 +709,7 @@ def _run_install_subprocess(
         A tuple of (returncode: int, stdout: str, stderr: str).
             returncode is -1 if cancelled, -2 if timed out.
     """
-    proc = subprocess.Popen(  # nosec B603 - internal command list, shell=False
+    proc = subprocess.Popen(  # nosec B603
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -927,7 +952,7 @@ def verify_venv(venv_dir=None, progress_callback=None):
         cmd = [python_path, "-c", verify_code]
 
         try:
-            result = subprocess.run(  # nosec B603 - internal command list, shell=False
+            result = subprocess.run(  # nosec B603
                 cmd,
                 capture_output=True,
                 text=True,
@@ -1002,7 +1027,7 @@ def _ensure_proj_data():
             _set_proj_data(proj_dir)
             return
     except Exception:
-        pass  # nosec B110 - fall through to next PROJ-data lookup strategy
+        pass  # nosec B110
 
     # Strategy 2: sys.prefix/share/proj (conda / pixi / OSGeo4W)
     candidate = os.path.join(sys.prefix, "share", "proj")
@@ -1021,7 +1046,7 @@ def _ensure_proj_data():
                     _set_proj_data(candidate)
                     return
     except Exception:
-        pass  # nosec B110 - fall through to next PROJ-data lookup strategy
+        pass  # nosec B110
 
     # Strategy 4: Search common system locations
     for candidate in (

--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -456,7 +456,9 @@ def create_venv(venv_dir=None, progress_callback=None):
 
     if use_uv:
         uv_path = get_uv_path()
-        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        uv_python = (
+            system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        )
         cmd = [uv_path, "venv"]
         if system_python is None:
             cmd.append("--managed-python")

--- a/nasa_earthdata/core/venv_manager.py
+++ b/nasa_earthdata/core/venv_manager.py
@@ -206,7 +206,7 @@ def _is_python_executable_name(path: str) -> bool:
 
 
 def _is_macos_qgis_app_bundle_python(path: str) -> bool:
-    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    """Return True for unsafe Python launchers in QGIS.app/Contents/MacOS."""
     if not (platform.system() == "Darwin" or sys.platform == "darwin"):
         return False
     parts = os.path.abspath(path).split(os.sep)
@@ -214,7 +214,12 @@ def _is_macos_qgis_app_bundle_python(path: str) -> bool:
         lower = part.lower()
         if not (lower.startswith("qgis") and lower.endswith(".app")):
             continue
-        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+        if idx + 2 >= len(parts):
+            return False
+        if parts[idx + 1].lower() != "contents" or parts[idx + 2].lower() != "macos":
+            return False
+        name = os.path.basename(path).lower()
+        return name.startswith("qgis") or _is_python_executable_name(path)
     return False
 
 
@@ -447,6 +452,12 @@ def create_venv(venv_dir=None, progress_callback=None):
         system_python = _get_system_python()
     except RuntimeError as exc:
         python_lookup_error = str(exc)
+    if python_lookup_error and system_python is None:
+        _log(
+            "Python lookup failed; falling back to uv-managed Python if "
+            f"available: {python_lookup_error}",
+            Qgis.MessageLevel.Warning,
+        )
     if system_python:
         _log(f"Using Python: {system_python}")
 
@@ -541,10 +552,12 @@ def create_venv(venv_dir=None, progress_callback=None):
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
+        missing_executable = cmd[0] if cmd else system_python
         _log(
-            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+            f"Venv creation executable not found: {missing_executable}",
+            Qgis.MessageLevel.Critical,
         )
-        return False, f"Python not found: {system_python}"
+        return False, f"Executable not found: {missing_executable}"
     except Exception as e:
         _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)

--- a/nasa_earthdata/metadata.txt
+++ b/nasa_earthdata/metadata.txt
@@ -3,7 +3,7 @@ name=NASA Earthdata
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Search, visualize, and download NASA Earthdata products in QGIS. Supports COG visualization and data footprint display.
-version=0.7.1
+version=0.7.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 

--- a/nasa_earthdata/metadata.txt
+++ b/nasa_earthdata/metadata.txt
@@ -36,7 +36,9 @@ icon=icons/icon.svg
 experimental=False
 deprecated=False
 
-changelog=Fix macOS QGIS installer dependency installation and bump patch version.
+changelog=
+    0.7.2
+        - Fix macOS QGIS installer dependency installation
     0.7.1
         - Fixed dependency installer Python detection for macOS QGIS app bundles
     0.7.0

--- a/nasa_earthdata/metadata.txt
+++ b/nasa_earthdata/metadata.txt
@@ -36,7 +36,7 @@ icon=icons/icon.svg
 experimental=False
 deprecated=False
 
-changelog=
+changelog=Fix macOS QGIS installer dependency installation and bump patch version.
     0.7.1
         - Fixed dependency installer Python detection for macOS QGIS app bundles
     0.7.0


### PR DESCRIPTION
## Summary
- Reject macOS QGIS app-bundle Python wrappers for dependency virtual environment creation where this plugin manages dependency venvs.
- Use uv-managed Python when no safe local Python interpreter is available.
- Bump the QGIS plugin patch version in `metadata.txt`.

## Root Cause
Official macOS QGIS installer builds can expose Python wrappers inside `QGIS*.app/Contents/MacOS` that either fail to start outside QGIS or create virtual environments pointing at the QGIS CI build prefix. Those venvs fail during dependency installation with missing stdlib modules such as `encodings`.

## Validation
- `python -m py_compile nasa_earthdata/core/venv_manager.py`
- Focused local QGIS plugin tests were run from the source checkout before publishing these PRs.
