### PR TITLE
ci: publish plugin to plugins.qgis.org on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish
+
+on:
+    release:
+        types: [published]
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag to publish (must already exist on GitHub)"
+                required: true
+                type: string
+
+permissions:
+    contents: write
+
+jobs:
+    publish:
+        name: Publish plugin to plugins.qgis.org
+        runs-on: ubuntu-latest
+        env:
+            TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+
+            - name: Build plugin zip
+              run: python package_plugin.py --output dist/nasa_earthdata.zip
+
+            - name: Verify metadata version matches release tag
+              run: |
+                  metadata_version=$(grep '^version=' nasa_earthdata/metadata.txt | cut -d'=' -f2 | tr -d '[:space:]')
+                  tag_version="${TAG#v}"
+                  if [ "$metadata_version" != "$tag_version" ]; then
+                      echo "::error::metadata.txt version ($metadata_version) does not match release tag ($tag_version)"
+                      exit 1
+                  fi
+
+            - name: Attach zip to GitHub release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh release upload "$TAG" dist/nasa_earthdata.zip --clobber
+
+            - name: Upload to plugins.qgis.org
+              env:
+                  QGIS_PLUGIN_REPO_USERNAME: ${{ secrets.QGIS_PLUGIN_REPO_USERNAME }}
+                  QGIS_PLUGIN_REPO_PASSWORD: ${{ secrets.QGIS_PLUGIN_REPO_PASSWORD }}
+              run: python scripts/upload_to_qgis_plugin_repo.py dist/nasa_earthdata.zip

--- a/scripts/upload_to_qgis_plugin_repo.py
+++ b/scripts/upload_to_qgis_plugin_repo.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Upload a packaged QGIS plugin zip to plugins.qgis.org via XML-RPC.
+
+The official plugin repository exposes an XML-RPC endpoint at
+``https://plugins.qgis.org/plugins/RPC2/`` with a ``plugin.upload`` method
+that accepts the zipped plugin as a base64-encoded ``Binary`` payload and
+returns the new plugin id and version id on success.
+
+Credentials must belong to a user with upload rights for the plugin and are
+read from the ``QGIS_PLUGIN_REPO_USERNAME`` and ``QGIS_PLUGIN_REPO_PASSWORD``
+environment variables so this script can be used from CI without leaking
+secrets onto the command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from urllib.parse import quote
+from xmlrpc.client import Binary, Fault, ProtocolError, ServerProxy
+
+REPO_URL_TEMPLATE = "https://{user}:{password}@plugins.qgis.org/plugins/RPC2/"
+
+
+def upload(zip_path: str, username: str, password: str) -> tuple[int, int]:
+    """Upload the given zip to plugins.qgis.org and return ``(plugin_id, version_id)``."""
+    with open(zip_path, "rb") as fh:
+        payload = Binary(fh.read())
+
+    endpoint = REPO_URL_TEMPLATE.format(
+        user=quote(username, safe=""),
+        password=quote(password, safe=""),
+    )
+    server = ServerProxy(endpoint, verbose=False)
+    plugin_id, version_id = server.plugin.upload(payload)
+    return plugin_id, version_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("zip_path", help="Path to the packaged plugin zip")
+    args = parser.parse_args()
+
+    username = os.environ.get("QGIS_PLUGIN_REPO_USERNAME")
+    password = os.environ.get("QGIS_PLUGIN_REPO_PASSWORD")
+    if not username or not password:
+        print(
+            "Error: QGIS_PLUGIN_REPO_USERNAME and QGIS_PLUGIN_REPO_PASSWORD must be set.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not os.path.isfile(args.zip_path):
+        print(f"Error: zip file not found: {args.zip_path}", file=sys.stderr)
+        return 1
+
+    try:
+        plugin_id, version_id = upload(args.zip_path, username, password)
+    except Fault as exc:
+        print(
+            f"Upload failed: {exc.faultString} (code {exc.faultCode})", file=sys.stderr
+        )
+        return 1
+    except ProtocolError as exc:
+        print(f"Upload failed: HTTP {exc.errcode} {exc.errmsg}", file=sys.stderr)
+        return 1
+
+    print(f"Uploaded plugin id={plugin_id}, version id={version_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a Publish workflow that builds the plugin zip with `package_plugin.py` when a GitHub release is published
- Attach the zip as a release asset and upload it to plugins.qgis.org via the XML-RPC endpoint
- Add `scripts/upload_to_qgis_plugin_repo.py` so the upload step is reusable from CI or locally

## Required repository secrets
Set these under Settings -> Secrets and variables -> Actions before the first release:
- `QGIS_PLUGIN_REPO_USERNAME` - osgeo.org username with upload rights for this plugin
- `QGIS_PLUGIN_REPO_PASSWORD` - matching osgeo.org password

## Notes
- Triggers on `release: published` and supports manual `workflow_dispatch` with a tag input for retries.
- Verifies that `metadata.txt` `version=` matches the release tag (with optional `v` prefix) before uploading.
- Re-uploading the same version is rejected by plugins.qgis.org, so bump `version=` in `metadata.txt` for every release.

## Test plan
- [ ] Add the two repository secrets listed above
- [ ] Cut a test pre-release (for example `v0.8.0-test1`) after bumping `metadata.txt` and verify the workflow attaches the zip and uploads to plugins.qgis.org
- [ ] Confirm the version mismatch check fails fast when `metadata.txt` and the tag disagree