### PR TITLE
feat: add saved searches, result export, and Processing provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ A QGIS plugin for searching, visualizing, and downloading NASA Earthdata product
 - **Search NASA Earthdata Catalog**: Browse and search thousands of NASA Earth science datasets using keywords, bounding boxes, and temporal filters
 - **Visualize Data Footprints**: Display search result footprints directly on the QGIS map canvas
 - **Cloud Optimized GeoTIFF (COG) Support**: Stream and visualize COG files directly without downloading
-- **Data Download**: Download granules for local processing and visualization
+- **Saved and Recent Searches**: Save reusable search presets, reload recent searches, and delete searches you no longer need
+- **Granule Details and Export**: Inspect selected granule metadata and export search results to CSV or GeoJSON
+- **Download Queue**: Download selected granules with queue status, cancel/retry controls, skip-existing behavior, and manifest output
+- **QGIS Processing Tools**: Run NASA Earthdata search, download, footprint, and RGB COG workflows from the Processing Toolbox and Model Designer
 - **Earthdata Login Integration**: Seamless authentication with NASA Earthdata Login credentials
 - **Settings Panel**: Configure credentials, download preferences, and plugin options
 
@@ -142,26 +145,58 @@ Alternatively, you can configure credentials via:
 
 1. Click the **NASA Earthdata Search** button in the toolbar
 2. Filter datasets by keyword (optional)
-3. Select a dataset from the dropdown
+3. Select a dataset from the dropdown. By default, the plugin selects `HLSL30` with concept ID `C2021957657-LPCLOUD` when it is available.
 4. Set the bounding box (or use current map extent)
 5. Set the date range
 6. Click **Search**
 
    ![](https://github.com/user-attachments/assets/5f41e258-662f-4441-84e5-d752971de573)
 
+The search panel is organized into collapsible sections. **Granule Details** and **Download Queue** are collapsed by default; expand them when you need metadata inspection or download status.
+
+### Saved and Recent Searches
+
+- Click **Save** in the **Preset** row to store the current dataset, bounding box, date range, max items, and advanced search options.
+- Select a saved preset and click **Load** to restore it.
+- Click **Delete** to remove the selected saved preset.
+- Recent searches are recorded automatically after each search. Select a recent item and click **Load** to restore it, or **Delete** to remove it from the recent list.
+
+Saved presets are stored in `~/.qgis_nasa_earthdata/workflows/search_presets.json` by default.
+
 ### Visualizing Data
 
 - **Footprints**: Search results are automatically displayed as footprints on the map
 - **COG Layers**: Select results and click **Display COG** to stream Cloud Optimized GeoTIFFs
+- **RGB Composite**: Select RGB mode and choose red, green, and blue COG channels to create a streamed RGB VRT layer
 - **Downloaded Data**: After downloading, you can add raster files directly to the map
+
+### Inspecting and Exporting Results
+
+- Select a result row and expand **Granule Details** to view native ID, dataset identity, provider, temporal range, size, COG availability, and data links.
+- Click **Export CSV** to write result metadata to `earthdata_results.csv`.
+- Click **Export GeoJSON** to write result metadata and footprints to `earthdata_results.geojson` and add the exported layer to the QGIS project.
 
 ### Downloading Data
 
 1. Select the granules you want to download from the results table
 2. Click **Download**
 3. Choose a destination folder
-4. Wait for the download to complete
-5. Optionally add downloaded files to the map
+4. Expand **Download Queue** to monitor per-granule status
+5. Optionally cancel the queue or retry failed items
+6. Optionally add downloaded files to the map
+
+The downloader skips files that already exist in the destination folder when their filenames match Earthdata link basenames. Each download run writes a CSV manifest in the selected output folder.
+
+### QGIS Processing
+
+The plugin registers a **NASA Earthdata** Processing provider with these algorithms:
+
+- **Search NASA Earthdata**: Search by short name or concept ID and optionally write result footprints to GeoJSON
+- **Download NASA Earthdata Granules**: Download granules from an exported Earthdata JSON input
+- **Add Earthdata Footprints**: Copy/export an Earthdata results GeoJSON as a Processing output
+- **Create RGB COG Layer**: Build an RGB VRT from red, green, and blue COG URLs or paths
+
+These tools can be run from **Processing** → **Toolbox** and used in QGIS Model Designer.
 
 ## Supported Datasets
 
@@ -187,11 +222,18 @@ qgis-nasa-earthdata-plugin/
 │   ├── nasa_earthdata.py    # Main plugin class
 │   ├── metadata.txt         # Plugin metadata
 │   ├── LICENSE
+│   ├── core/                # Network, environment, and workflow helpers
+│   │   ├── net.py
+│   │   ├── workflows.py
+│   │   └── venv_manager.py
 │   ├── dialogs/             # UI components
 │   │   ├── __init__.py
 │   │   ├── earthdata_dock.py    # Main search panel
 │   │   ├── settings_dock.py     # Settings panel
 │   │   └── update_checker.py    # Update checker dialog
+│   ├── processing/          # QGIS Processing provider and algorithms
+│   │   ├── provider.py
+│   │   └── algorithms.py
 │   └── icons/               # Plugin icons
 │       ├── icon.svg
 │       ├── settings.svg

--- a/nasa_earthdata/core/workflows.py
+++ b/nasa_earthdata/core/workflows.py
@@ -1,0 +1,412 @@
+"""Workflow helpers for NASA Earthdata searches, exports, and downloads."""
+
+import csv
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+PRESET_SCHEMA_VERSION = 1
+RESULT_EXPORT_FIELDS = [
+    "result_idx",
+    "native_id",
+    "dataset_short_name",
+    "dataset_concept_id",
+    "dataset_provider",
+    "dataset_version",
+    "dataset_title",
+    "temporal_start",
+    "temporal_end",
+    "size_bytes",
+    "size_display",
+    "cloud_cover",
+    "day_night",
+    "provider",
+    "collection_concept_id",
+    "granule_ur",
+    "links",
+    "cog_links",
+]
+
+
+def utc_timestamp():
+    """Return an ISO-8601 UTC timestamp with a trailing Z."""
+    return (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+
+def workflow_dir(settings=None):
+    """Return the directory used for saved searches and exported manifests."""
+    configured = ""
+    if settings is not None:
+        configured = settings.value("NASAEarthdata/workflow_dir", "", type=str)
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".qgis_nasa_earthdata" / "workflows"
+
+
+def presets_path(settings=None):
+    """Return the JSON file path used for saved search presets."""
+    return workflow_dir(settings) / "search_presets.json"
+
+
+def manifests_dir(settings=None):
+    """Return the directory used for download manifests."""
+    return workflow_dir(settings) / "manifests"
+
+
+def load_search_presets(path):
+    """Load search presets from disk."""
+    path = Path(path)
+    if not path.exists():
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if isinstance(payload, list):
+        return payload
+    return payload.get("presets", [])
+
+
+def save_search_presets(path, presets):
+    """Write search presets to disk using a stable schema."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": PRESET_SCHEMA_VERSION,
+        "updated_at": utc_timestamp(),
+        "presets": presets,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+
+
+def upsert_search_preset(path, preset):
+    """Insert or replace a named search preset."""
+    presets = [
+        existing
+        for existing in load_search_presets(path)
+        if existing.get("name") != preset.get("name")
+    ]
+    presets.insert(0, preset)
+    save_search_presets(path, presets)
+    return presets
+
+
+def delete_search_preset(path, name):
+    """Delete saved search presets matching ``name``."""
+    presets = [
+        existing
+        for existing in load_search_presets(path)
+        if existing.get("name") != name
+    ]
+    save_search_presets(path, presets)
+    return presets
+
+
+def build_search_preset(
+    name,
+    dataset_item,
+    bbox_text,
+    start_date,
+    end_date,
+    max_items,
+    advanced_options=None,
+):
+    """Build a serializable search preset from dock state."""
+    dataset_item = dataset_item or {}
+    return {
+        "schema_version": PRESET_SCHEMA_VERSION,
+        "name": name,
+        "created_at": utc_timestamp(),
+        "dataset": {
+            "label": dataset_item.get("label", ""),
+            "short_name": dataset_item.get("short_name", ""),
+            "concept_id": dataset_item.get("concept_id", ""),
+            "provider": dataset_item.get("provider", ""),
+            "version": dataset_item.get("version", ""),
+            "title": dataset_item.get("title", ""),
+        },
+        "bbox": bbox_text or "",
+        "temporal": {"start": start_date or "", "end": end_date or ""},
+        "max_items": int(max_items),
+        "advanced": advanced_options or {},
+    }
+
+
+def record_recent_search(settings, preset, limit=10):
+    """Store a compact recent-search list in QSettings."""
+    if settings is None:
+        return []
+    raw = settings.value("NASAEarthdata/recent_searches", "[]", type=str)
+    try:
+        recent = json.loads(raw) if raw else []
+    except Exception:
+        recent = []
+    signature = _preset_signature(preset)
+    recent = [item for item in recent if _preset_signature(item) != signature]
+    recent.insert(0, preset)
+    recent = recent[:limit]
+    settings.setValue("NASAEarthdata/recent_searches", json.dumps(recent))
+    settings.sync()
+    return recent
+
+
+def load_recent_searches(settings):
+    """Load recent searches from QSettings."""
+    if settings is None:
+        return []
+    raw = settings.value("NASAEarthdata/recent_searches", "[]", type=str)
+    try:
+        value = json.loads(raw) if raw else []
+        return value if isinstance(value, list) else []
+    except Exception:
+        return []
+
+
+def save_recent_searches(settings, recent):
+    """Save recent searches to QSettings."""
+    if settings is None:
+        return []
+    settings.setValue("NASAEarthdata/recent_searches", json.dumps(recent))
+    settings.sync()
+    return recent
+
+
+def delete_recent_search(settings, index):
+    """Delete one recent search by list index."""
+    recent = load_recent_searches(settings)
+    if 0 <= index < len(recent):
+        del recent[index]
+    return save_recent_searches(settings, recent)
+
+
+def _preset_signature(preset):
+    """Return a stable identity for deduplicating recent searches."""
+    dataset = preset.get("dataset", {})
+    temporal = preset.get("temporal", {})
+    return (
+        dataset.get("concept_id") or dataset.get("short_name"),
+        preset.get("bbox", ""),
+        temporal.get("start", ""),
+        temporal.get("end", ""),
+        json.dumps(preset.get("advanced", {}), sort_keys=True),
+    )
+
+
+def granule_get(granule, *path, default=None):
+    """Read nested dict-like granule values."""
+    current = granule
+    for key in path:
+        try:
+            current = current.get(key, default)
+        except AttributeError:
+            return default
+        if current is None:
+            return default
+    return current
+
+
+def granule_native_id(granule, fallback=""):
+    """Return the best available native granule ID."""
+    return (
+        granule_get(granule, "meta", "native-id")
+        or granule_get(granule, "umm", "GranuleUR")
+        or fallback
+    )
+
+
+def granule_temporal_range(granule):
+    """Return beginning and ending timestamps from a granule."""
+    range_dt = granule_get(
+        granule,
+        "umm",
+        "TemporalExtent",
+        "RangeDateTime",
+        default={},
+    )
+    if not isinstance(range_dt, dict):
+        return "", ""
+    return range_dt.get("BeginningDateTime", ""), range_dt.get("EndingDateTime", "")
+
+
+def granule_size_bytes(granule):
+    """Return the first declared archive size in bytes."""
+    infos = granule_get(
+        granule,
+        "umm",
+        "DataGranule",
+        "ArchiveAndDistributionInformation",
+        default=[],
+    )
+    if not isinstance(infos, list):
+        return 0
+    for info in infos:
+        try:
+            return int(float(info.get("SizeInBytes", 0) or 0))
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def format_size(size_bytes):
+    """Format a byte count for display."""
+    if size_bytes <= 0:
+        return "N/A"
+    if size_bytes > 1e9:
+        return f"{size_bytes / 1e9:.1f} GB"
+    if size_bytes > 1e6:
+        return f"{size_bytes / 1e6:.1f} MB"
+    return f"{size_bytes / 1e3:.1f} KB"
+
+
+def granule_links(granule):
+    """Return data links from an earthaccess granule or UMM RelatedUrls."""
+    links = []
+    try:
+        try:
+            links = list(granule.data_links(access="external"))
+        except TypeError:
+            links = list(granule.data_links())
+    except Exception:
+        links = []
+    if links:
+        return list(dict.fromkeys(str(link) for link in links if link))
+
+    related_urls = granule_get(granule, "umm", "RelatedUrls", default=[])
+    if isinstance(related_urls, list):
+        for item in related_urls:
+            if isinstance(item, dict) and item.get("URL"):
+                links.append(str(item["URL"]))
+    return list(dict.fromkeys(links))
+
+
+def cog_links_from_links(links):
+    """Return HTTPS TIFF/COG-looking links."""
+    return [
+        link
+        for link in links
+        if link.lower().startswith("http")
+        and any(ext in link.lower() for ext in (".tif", ".tiff"))
+    ]
+
+
+def granule_export_row(granule, result_idx, dataset_item=None):
+    """Convert a granule into a stable flat export row."""
+    dataset_item = dataset_item or {}
+    links = granule_links(granule)
+    cog_links = cog_links_from_links(links)
+    temporal_start, temporal_end = granule_temporal_range(granule)
+    size_bytes = granule_size_bytes(granule)
+    return {
+        "result_idx": result_idx,
+        "native_id": granule_native_id(granule, f"Item {result_idx + 1}"),
+        "dataset_short_name": dataset_item.get("short_name", ""),
+        "dataset_concept_id": dataset_item.get("concept_id", ""),
+        "dataset_provider": dataset_item.get("provider", ""),
+        "dataset_version": dataset_item.get("version", ""),
+        "dataset_title": dataset_item.get("title", ""),
+        "temporal_start": temporal_start,
+        "temporal_end": temporal_end,
+        "size_bytes": size_bytes,
+        "size_display": format_size(size_bytes),
+        "cloud_cover": granule_get(granule, "umm", "CloudCover", default=""),
+        "day_night": granule_get(
+            granule, "umm", "DataGranule", "DayNightFlag", default=""
+        ),
+        "provider": granule_get(granule, "meta", "provider-id", default=""),
+        "collection_concept_id": granule_get(
+            granule, "umm", "CollectionReference", "ConceptID", default=""
+        ),
+        "granule_ur": granule_get(granule, "umm", "GranuleUR", default=""),
+        "links": "\n".join(links),
+        "cog_links": "\n".join(cog_links),
+    }
+
+
+def granules_to_export_rows(granules, dataset_item=None):
+    """Convert granules to export rows."""
+    return [
+        granule_export_row(granule, index, dataset_item)
+        for index, granule in enumerate(granules or [])
+    ]
+
+
+def write_results_csv(path, rows):
+    """Write result metadata rows to CSV."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=RESULT_EXPORT_FIELDS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {field: row.get(field, "") for field in RESULT_EXPORT_FIELDS}
+            )
+
+
+def write_results_geojson(path, rows, gdf=None):
+    """Write result metadata and optional geometries to GeoJSON."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    features = []
+    for index, row in enumerate(rows):
+        geometry = None
+        if gdf is not None:
+            try:
+                geom = gdf.geometry.iloc[index]
+                if geom is not None and not geom.is_empty:
+                    geometry = geom.__geo_interface__
+            except Exception:
+                geometry = None
+        features.append(
+            {
+                "type": "Feature",
+                "properties": {
+                    key: value for key, value in row.items() if key != "links"
+                },
+                "geometry": geometry,
+            }
+        )
+    payload = {"type": "FeatureCollection", "features": features}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+
+def likely_existing_download_files(granule, output_dir):
+    """Return files in ``output_dir`` matching link basenames for a granule."""
+    output_dir = Path(output_dir)
+    existing = []
+    for link in granule_links(granule):
+        filename = os.path.basename(str(link).split("?")[0])
+        if not filename:
+            continue
+        path = output_dir / filename
+        if path.exists():
+            existing.append(str(path))
+    return existing
+
+
+def download_manifest_path(output_dir):
+    """Return a timestamped manifest path for a download queue."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return Path(output_dir) / f"nasa_earthdata_download_manifest_{timestamp}.csv"
+
+
+def write_download_manifest(path, rows):
+    """Write download queue results to a manifest CSV."""
+    fieldnames = ["index", "native_id", "status", "message", "files"]
+    path = Path(path)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "index": row.get("index", ""),
+                    "native_id": row.get("native_id", ""),
+                    "status": row.get("status", ""),
+                    "message": row.get("message", ""),
+                    "files": "\n".join(str(item) for item in row.get("files", [])),
+                }
+            )

--- a/nasa_earthdata/core/workflows.py
+++ b/nasa_earthdata/core/workflows.py
@@ -397,6 +397,7 @@ def write_download_manifest(path, rows):
     """Write download queue results to a manifest CSV."""
     fieldnames = ["index", "native_id", "status", "message", "files"]
     path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", encoding="utf-8", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -57,6 +57,7 @@ from qgis.core import (
 from ..core.net import https_only_urlopen
 from ..core.workflows import (
     build_search_preset,
+    cog_links_from_links,
     delete_recent_search,
     delete_search_preset,
     download_manifest_path,
@@ -2421,7 +2422,7 @@ class EarthdataDockWidget(QDockWidget):
         dataset_item = self.dataset_combo.currentData() or {}
         row = granule_export_row(granule, result_index, dataset_item)
         links = granule_links(granule)
-        cog_links = [link for link in links if link in row.get("cog_links", "")]
+        cog_links = cog_links_from_links(links)
         lines = [
             f"Native ID: {row.get('native_id', '')}",
             f"Dataset: {row.get('dataset_short_name', '')}",

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -42,6 +42,7 @@ from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QListWidget,
     QListWidgetItem,
+    QInputDialog,
 )
 from qgis.PyQt.QtGui import QFont
 from qgis.core import (
@@ -54,6 +55,25 @@ from qgis.core import (
 )
 
 from ..core.net import https_only_urlopen
+from ..core.workflows import (
+    build_search_preset,
+    delete_recent_search,
+    delete_search_preset,
+    download_manifest_path,
+    granule_export_row,
+    granule_links,
+    granule_native_id,
+    granules_to_export_rows,
+    likely_existing_download_files,
+    load_recent_searches,
+    load_search_presets,
+    record_recent_search,
+    upsert_search_preset,
+    workflow_dir,
+    write_download_manifest,
+    write_results_csv,
+    write_results_geojson,
+)
 
 # NASA Earthdata TSV URL
 NASA_DATA_URL = (
@@ -221,39 +241,49 @@ class CatalogLoadWorker(QThread):
     error = pyqtSignal(str)
     progress = pyqtSignal(str)
 
-    def __init__(self, force_refresh=False, parent=None):
+    def __init__(
+        self,
+        force_refresh=False,
+        catalog_url=None,
+        cache_dir=None,
+        cache_enabled=True,
+        parent=None,
+    ):
         super().__init__(parent)
         self.force_refresh = force_refresh
+        self.catalog_url = catalog_url or NASA_DATA_URL
+        self.cache_dir = Path(cache_dir).expanduser() if cache_dir else CACHE_DIR
+        self.cache_enabled = cache_enabled
 
     def run(self):
         """Load the catalog from cache or download."""
         try:
             import csv
 
-            # Ensure cache directory exists
-            CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            cache_file = self.cache_dir / CATALOG_CACHE_FILE.name
+            if self.cache_enabled:
+                self.cache_dir.mkdir(parents=True, exist_ok=True)
 
             # Check if cache exists and is fresh
             use_cache = False
-            if not self.force_refresh and CATALOG_CACHE_FILE.exists():
-                cache_age = (
-                    datetime.now().timestamp() - CATALOG_CACHE_FILE.stat().st_mtime
-                )
+            if self.cache_enabled and not self.force_refresh and cache_file.exists():
+                cache_age = datetime.now().timestamp() - cache_file.stat().st_mtime
                 if cache_age < CATALOG_CACHE_MAX_AGE_DAYS * 24 * 3600:
                     use_cache = True
                     self.progress.emit("Loading catalog from cache...")
 
             if use_cache:
-                with open(CATALOG_CACHE_FILE, "r", encoding="utf-8") as f:
+                with open(cache_file, "r", encoding="utf-8") as f:
                     reader = csv.DictReader(f, delimiter="\t")
                     rows = list(reader)
             else:
                 self.progress.emit("Downloading NASA Earthdata catalog...")
-                with https_only_urlopen(NASA_DATA_URL, timeout=30) as resp:
+                with https_only_urlopen(self.catalog_url, timeout=30) as resp:
                     text = resp.read().decode("utf-8")
                 # Save raw TSV to cache
-                with open(CATALOG_CACHE_FILE, "w", encoding="utf-8") as f:
-                    f.write(text)
+                if self.cache_enabled:
+                    with open(cache_file, "w", encoding="utf-8") as f:
+                        f.write(text)
                 reader = csv.DictReader(text.splitlines(), delimiter="\t")
                 rows = list(reader)
 
@@ -663,33 +693,125 @@ class COGDisplayWorker(QThread):
 class DataDownloadWorker(QThread):
     """Worker thread for downloading NASA Earthdata."""
 
-    finished = pyqtSignal(list)  # downloaded files
+    finished = pyqtSignal(list, str, list)  # downloaded files, manifest, queue rows
     error = pyqtSignal(str)
     progress = pyqtSignal(int, str)
+    queue_update = pyqtSignal(int, str, str, list)  # row, status, message, files
 
-    def __init__(self, granules, output_dir, parent=None):
+    def __init__(
+        self,
+        granules,
+        output_dir,
+        threads=1,
+        skip_existing=True,
+        parent=None,
+    ):
         super().__init__(parent)
         self.granules = granules
         self.output_dir = output_dir
+        self.threads = max(1, int(threads or 1))
+        self.skip_existing = skip_existing
+        self._cancelled = False
+
+    def cancel(self):
+        """Request cancellation after the current granule finishes."""
+        self._cancelled = True
 
     def run(self):
         """Execute the download."""
         try:
+            import inspect
+
             from ..core.venv_manager import import_earthaccess
 
             earthaccess = import_earthaccess()
 
-            self.progress.emit(10, "Authenticating...")
+            total = len(self.granules or [])
+            if total == 0:
+                self.finished.emit([], "", [])
+                return
 
-            self.progress.emit(30, "Downloading files...")
+            self.progress.emit(5, "Preparing download queue...")
+            downloaded_files = []
+            queue_rows = []
+            download_kwargs = {"local_path": self.output_dir}
+            try:
+                signature = inspect.signature(earthaccess.download)
+                if "threads" in signature.parameters:
+                    download_kwargs["threads"] = self.threads
+                elif "n_threads" in signature.parameters:
+                    download_kwargs["n_threads"] = self.threads
+            except Exception:
+                pass  # nosec B110
 
-            files = earthaccess.download(
-                self.granules,
-                local_path=self.output_dir,
-            )
+            for index, granule in enumerate(self.granules):
+                native_id = granule_native_id(granule, f"Item {index + 1}")
+                if self._cancelled:
+                    row = {
+                        "index": index,
+                        "native_id": native_id,
+                        "status": "cancelled",
+                        "message": "Cancelled before download",
+                        "files": [],
+                    }
+                    queue_rows.append(row)
+                    self.queue_update.emit(index, "cancelled", row["message"], [])
+                    continue
 
-            self.progress.emit(100, "Download complete!")
-            self.finished.emit(files)
+                existing = (
+                    likely_existing_download_files(granule, self.output_dir)
+                    if self.skip_existing
+                    else []
+                )
+                if existing:
+                    message = f"Skipped {len(existing)} existing file(s)"
+                    row = {
+                        "index": index,
+                        "native_id": native_id,
+                        "status": "skipped",
+                        "message": message,
+                        "files": existing,
+                    }
+                    queue_rows.append(row)
+                    downloaded_files.extend(existing)
+                    self.queue_update.emit(index, "skipped", message, existing)
+                    continue
+
+                percent = int((index / total) * 90) + 5
+                self.progress.emit(
+                    percent, f"Downloading {index + 1}/{total}: {native_id}"
+                )
+                self.queue_update.emit(index, "running", "Downloading...", [])
+                try:
+                    files = earthaccess.download([granule], **download_kwargs) or []
+                    files = [str(file_path) for file_path in files]
+                    downloaded_files.extend(files)
+                    message = f"Downloaded {len(files)} file(s)"
+                    row = {
+                        "index": index,
+                        "native_id": native_id,
+                        "status": "done",
+                        "message": message,
+                        "files": files,
+                    }
+                    queue_rows.append(row)
+                    self.queue_update.emit(index, "done", message, files)
+                except Exception as e:
+                    message = str(e)
+                    row = {
+                        "index": index,
+                        "native_id": native_id,
+                        "status": "failed",
+                        "message": message,
+                        "files": [],
+                    }
+                    queue_rows.append(row)
+                    self.queue_update.emit(index, "failed", message, [])
+
+            manifest = str(download_manifest_path(self.output_dir))
+            write_download_manifest(manifest, queue_rows)
+            self.progress.emit(100, "Download queue complete!")
+            self.finished.emit(downloaded_files, manifest, queue_rows)
 
         except Exception as e:
             self.error.emit(str(e))
@@ -727,6 +849,12 @@ class EarthdataDockWidget(QDockWidget):
         self._bbox_map_tool = None
         self._previous_map_tool = None
         self._adjusting_results_columns = False
+        self._adjusting_download_columns = False
+        self._saved_presets = []
+        self._recent_searches = []
+        self._last_download_granules = []
+        self._last_download_output_dir = ""
+        self._last_download_rows = []
 
         # Workers
         self._catalog_worker = None
@@ -773,7 +901,7 @@ class EarthdataDockWidget(QDockWidget):
         layout.addLayout(header_layout)
 
         # Search section
-        search_group = QGroupBox("Search Parameters")
+        search_group = QGroupBox()
         search_layout = QFormLayout(search_group)
         search_layout.setFieldGrowthPolicy(
             QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow
@@ -812,7 +940,9 @@ class EarthdataDockWidget(QDockWidget):
         # Max items
         self.max_items_spin = QSpinBox()
         self.max_items_spin.setRange(1, 500)
-        self.max_items_spin.setValue(50)
+        self.max_items_spin.setValue(
+            self.settings.value("NASAEarthdata/default_max_items", 50, type=int)
+        )
         search_layout.addRow("Max Items:", self.max_items_spin)
 
         # Bounding box
@@ -853,7 +983,37 @@ class EarthdataDockWidget(QDockWidget):
         date_layout.addWidget(self.end_date)
         search_layout.addRow("Date Range:", date_layout)
 
-        layout.addWidget(search_group)
+        # Saved and recent searches
+        preset_layout = QHBoxLayout()
+        self.preset_combo = QComboBox()
+        self.preset_combo.setToolTip("Saved search presets")
+        preset_layout.addWidget(self.preset_combo, 1)
+        self.load_preset_btn = QPushButton("Load")
+        self.load_preset_btn.clicked.connect(self._load_selected_preset)
+        preset_layout.addWidget(self.load_preset_btn)
+        self.save_preset_btn = QPushButton("Save")
+        self.save_preset_btn.clicked.connect(self._save_current_preset)
+        preset_layout.addWidget(self.save_preset_btn)
+        self.delete_preset_btn = QPushButton("Delete")
+        self.delete_preset_btn.clicked.connect(self._delete_selected_preset)
+        preset_layout.addWidget(self.delete_preset_btn)
+        search_layout.addRow("Preset:", preset_layout)
+
+        recent_layout = QHBoxLayout()
+        self.recent_combo = QComboBox()
+        self.recent_combo.setToolTip("Recent search parameters")
+        recent_layout.addWidget(self.recent_combo, 1)
+        self.load_recent_btn = QPushButton("Load")
+        self.load_recent_btn.clicked.connect(self._load_selected_recent)
+        recent_layout.addWidget(self.load_recent_btn)
+        self.delete_recent_btn = QPushButton("Delete")
+        self.delete_recent_btn.clicked.connect(self._delete_selected_recent)
+        recent_layout.addWidget(self.delete_recent_btn)
+        search_layout.addRow("Recent:", recent_layout)
+
+        self.search_section_check = self._add_collapsible_section(
+            layout, "Search Parameters", search_group, checked=True
+        )
 
         # Advanced Options (collapsible checkbox)
         self.advanced_check = QCheckBox("Advanced Options")
@@ -974,7 +1134,7 @@ class EarthdataDockWidget(QDockWidget):
         layout.addWidget(self.progress_bar)
 
         # Results section
-        results_group = QGroupBox("Search Results")
+        results_group = QGroupBox()
         results_layout = QVBoxLayout(results_group)
 
         # Results table
@@ -1009,6 +1169,19 @@ class EarthdataDockWidget(QDockWidget):
             self._on_header_double_clicked
         )
         results_layout.addWidget(self.results_table)
+
+        # Selected granule detail inspector
+        details_group = QGroupBox()
+        details_layout = QVBoxLayout(details_group)
+        self.details_text = QTextEdit()
+        self.details_text.setReadOnly(True)
+        self.details_text.setMinimumHeight(90)
+        self.details_text.setMaximumHeight(160)
+        self.details_text.setPlaceholderText("Select a result to inspect metadata...")
+        details_layout.addWidget(self.details_text)
+        self.details_section_check = self._add_collapsible_section(
+            results_layout, "Granule Details", details_group, checked=False
+        )
 
         # COG file selection controls
         cog_mode_layout = QHBoxLayout()
@@ -1062,6 +1235,14 @@ class EarthdataDockWidget(QDockWidget):
         self.zoom_footprints_btn.setEnabled(False)
         self.zoom_footprints_btn.clicked.connect(self._zoom_to_footprints)
         info_layout.addWidget(self.zoom_footprints_btn)
+        self.export_csv_btn = QPushButton("Export CSV")
+        self.export_csv_btn.setEnabled(False)
+        self.export_csv_btn.clicked.connect(self._export_results_csv)
+        info_layout.addWidget(self.export_csv_btn)
+        self.export_geojson_btn = QPushButton("Export GeoJSON")
+        self.export_geojson_btn.setEnabled(False)
+        self.export_geojson_btn.clicked.connect(self._export_results_geojson)
+        info_layout.addWidget(self.export_geojson_btn)
         info_layout.addStretch()
         results_layout.addLayout(info_layout)
 
@@ -1070,10 +1251,12 @@ class EarthdataDockWidget(QDockWidget):
         self.results_label.setStyleSheet("color: gray;")
         results_layout.addWidget(self.results_label)
 
-        layout.addWidget(results_group)
+        self.results_section_check = self._add_collapsible_section(
+            layout, "Search Results", results_group, checked=True
+        )
 
         # Output section
-        output_group = QGroupBox("Output")
+        output_group = QGroupBox()
         output_layout = QVBoxLayout(output_group)
         output_layout.setContentsMargins(6, 6, 6, 6)
         output_group.setSizePolicy(
@@ -1089,19 +1272,81 @@ class EarthdataDockWidget(QDockWidget):
         self.output_text.setPlaceholderText("Status messages will appear here...")
         output_layout.addWidget(self.output_text)
 
-        layout.addWidget(output_group, 1)
+        self.output_section_check = self._add_collapsible_section(
+            layout, "Output", output_group, checked=True, stretch=1
+        )
+
+        # Download queue section
+        download_group = QGroupBox()
+        download_layout = QVBoxLayout(download_group)
+        self.download_queue_table = QTableWidget()
+        self.download_queue_table.setColumnCount(4)
+        self.download_queue_table.setHorizontalHeaderLabels(
+            ["Granule", "Status", "Message", "Files"]
+        )
+        download_header = self.download_queue_table.horizontalHeader()
+        download_header.setSectionsClickable(True)
+        download_header.setSectionsMovable(False)
+        download_header.setMinimumSectionSize(45)
+        download_header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        download_header.setStretchLastSection(False)
+        download_header.sectionResized.connect(self._on_download_section_resized)
+        self._set_default_download_column_widths()
+        self.download_queue_table.installEventFilter(self)
+        self.download_queue_table.viewport().installEventFilter(self)
+        self.download_queue_table.setMinimumHeight(90)
+        download_layout.addWidget(self.download_queue_table)
+        download_btn_layout = QHBoxLayout()
+        self.cancel_download_btn = QPushButton("Cancel Download")
+        self.cancel_download_btn.setEnabled(False)
+        self.cancel_download_btn.clicked.connect(self._cancel_download)
+        download_btn_layout.addWidget(self.cancel_download_btn)
+        self.retry_failed_btn = QPushButton("Retry Failed")
+        self.retry_failed_btn.setEnabled(False)
+        self.retry_failed_btn.clicked.connect(self._retry_failed_downloads)
+        download_btn_layout.addWidget(self.retry_failed_btn)
+        download_btn_layout.addStretch()
+        download_layout.addLayout(download_btn_layout)
+        self.download_section_check = self._add_collapsible_section(
+            layout, "Download Queue", download_group, checked=False
+        )
 
         # Status label
         self.status_label = QLabel("Ready")
         self.status_label.setStyleSheet("color: gray; font-size: 10px;")
         layout.addWidget(self.status_label)
 
+        self._load_presets_into_combo()
+        self._load_recent_into_combo()
+
+    def _add_collapsible_section(self, layout, title, widget, checked=True, stretch=0):
+        """Add a checkbox-controlled section to a layout."""
+        checkbox = QCheckBox(title)
+        checkbox.setChecked(checked)
+        checkbox.toggled.connect(widget.setVisible)
+        layout.addWidget(checkbox)
+        widget.setVisible(checked)
+        if stretch:
+            layout.addWidget(widget, stretch)
+        else:
+            layout.addWidget(widget)
+        return checkbox
+
     def _load_datasets(self):
         """Load NASA datasets from cache or download."""
         self._log("Loading NASA Earthdata catalog...")
         self.refresh_catalog_btn.setEnabled(False)
 
-        self._catalog_worker = CatalogLoadWorker(force_refresh=False)
+        self._catalog_worker = CatalogLoadWorker(
+            force_refresh=False,
+            catalog_url=self.settings.value(
+                "NASAEarthdata/catalog_url", NASA_DATA_URL, type=str
+            ),
+            cache_dir=self.settings.value("NASAEarthdata/cache_dir", "", type=str),
+            cache_enabled=self.settings.value(
+                "NASAEarthdata/enable_cache", True, type=bool
+            ),
+        )
         self._catalog_worker.finished.connect(self._on_catalog_loaded)
         self._catalog_worker.error.connect(self._on_catalog_error)
         self._catalog_worker.progress.connect(self._log)
@@ -1112,7 +1357,16 @@ class EarthdataDockWidget(QDockWidget):
         self._log("Refreshing catalog from server...")
         self.refresh_catalog_btn.setEnabled(False)
 
-        self._catalog_worker = CatalogLoadWorker(force_refresh=True)
+        self._catalog_worker = CatalogLoadWorker(
+            force_refresh=True,
+            catalog_url=self.settings.value(
+                "NASAEarthdata/catalog_url", NASA_DATA_URL, type=str
+            ),
+            cache_dir=self.settings.value("NASAEarthdata/cache_dir", "", type=str),
+            cache_enabled=self.settings.value(
+                "NASAEarthdata/enable_cache", True, type=bool
+            ),
+        )
         self._catalog_worker.finished.connect(self._on_catalog_loaded)
         self._catalog_worker.error.connect(self._on_catalog_error)
         self._catalog_worker.progress.connect(self._log)
@@ -1121,6 +1375,192 @@ class EarthdataDockWidget(QDockWidget):
     def reload_catalog(self):
         """Reload the catalog, e.g. after dependencies are installed."""
         self._load_datasets()
+
+    def _presets_file(self):
+        """Return saved-search preset storage path."""
+        return workflow_dir(self.settings) / "search_presets.json"
+
+    def _load_presets_into_combo(self):
+        """Load saved search presets into the combo box."""
+        try:
+            self._saved_presets = load_search_presets(self._presets_file())
+        except Exception as e:
+            self._saved_presets = []
+            self._log(f"Could not load saved searches: {e}", error=True)
+
+        self.preset_combo.blockSignals(True)
+        self.preset_combo.clear()
+        for preset in self._saved_presets:
+            self.preset_combo.addItem(preset.get("name", "Unnamed Search"), preset)
+        self.preset_combo.blockSignals(False)
+        self.load_preset_btn.setEnabled(bool(self._saved_presets))
+        self.delete_preset_btn.setEnabled(bool(self._saved_presets))
+
+    def _load_recent_into_combo(self):
+        """Load recent searches into the combo box."""
+        self._recent_searches = load_recent_searches(self.settings)
+        self.recent_combo.blockSignals(True)
+        self.recent_combo.clear()
+        for preset in self._recent_searches:
+            dataset = preset.get("dataset", {})
+            temporal = preset.get("temporal", {})
+            label = (
+                f"{dataset.get('short_name') or dataset.get('label', 'Dataset')} "
+                f"{temporal.get('start', '')} to {temporal.get('end', '')}"
+            ).strip()
+            self.recent_combo.addItem(label, preset)
+        self.recent_combo.blockSignals(False)
+        self.load_recent_btn.setEnabled(bool(self._recent_searches))
+        self.delete_recent_btn.setEnabled(bool(self._recent_searches))
+
+    def _current_advanced_options(self):
+        """Return current advanced search UI options."""
+        return {
+            "enabled": self.advanced_check.isChecked(),
+            "cloud_min": self.cloud_min_spin.value(),
+            "cloud_max": self.cloud_max_spin.value(),
+            "day_night": self.daynight_combo.currentData(),
+            "provider": self.provider_input.text().strip(),
+            "version": self.version_input.text().strip(),
+            "granule_id": self.granule_id_input.text().strip(),
+            "orbit_min": self.orbit_min_spin.value(),
+            "orbit_max": self.orbit_max_spin.value(),
+        }
+
+    def _current_search_preset(self, name):
+        """Build a search preset from current UI state."""
+        return build_search_preset(
+            name=name,
+            dataset_item=self.dataset_combo.currentData() or {},
+            bbox_text=self.bbox_input.text().strip(),
+            start_date=self.start_date.date().toString("yyyy-MM-dd"),
+            end_date=self.end_date.date().toString("yyyy-MM-dd"),
+            max_items=self.max_items_spin.value(),
+            advanced_options=self._current_advanced_options(),
+        )
+
+    def _save_current_preset(self):
+        """Prompt for a name and save the current search as a preset."""
+        default_name = self.dataset_combo.currentText() or "NASA Earthdata Search"
+        name, ok = QInputDialog.getText(
+            self,
+            "Save Search Preset",
+            "Preset name:",
+            text=default_name,
+        )
+        name = name.strip()
+        if not ok or not name:
+            return
+
+        try:
+            upsert_search_preset(
+                self._presets_file(), self._current_search_preset(name)
+            )
+            self._load_presets_into_combo()
+            self._log(f"Saved search preset: {name}")
+        except Exception as e:
+            QMessageBox.critical(self, "Save Search Preset", f"Failed to save:\n{e}")
+
+    def _delete_selected_preset(self):
+        """Delete the selected saved search preset."""
+        index = self.preset_combo.currentIndex()
+        preset = self.preset_combo.currentData()
+        if index < 0 or not preset:
+            return
+
+        name = preset.get("name", self.preset_combo.currentText())
+        reply = QMessageBox.question(
+            self,
+            "Delete Search Preset",
+            f"Delete saved search preset '{name}'?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            delete_search_preset(self._presets_file(), name)
+            self._load_presets_into_combo()
+            self._log(f"Deleted search preset: {name}")
+        except Exception as e:
+            QMessageBox.critical(
+                self, "Delete Search Preset", f"Failed to delete:\n{e}"
+            )
+
+    def _delete_selected_recent(self):
+        """Delete the selected recent search."""
+        index = self.recent_combo.currentIndex()
+        if index < 0:
+            return
+
+        delete_recent_search(self.settings, index)
+        self._load_recent_into_combo()
+        self._log("Deleted recent search")
+
+    def _select_dataset_from_preset(self, preset):
+        """Select the dataset matching a preset."""
+        dataset = preset.get("dataset", {})
+        concept_id = dataset.get("concept_id", "")
+        short_name = dataset.get("short_name", "")
+        for index in range(self.dataset_combo.count()):
+            item = self.dataset_combo.itemData(index) or {}
+            if concept_id and item.get("concept_id") == concept_id:
+                self.dataset_combo.setCurrentIndex(index)
+                return
+            if short_name and item.get("short_name") == short_name:
+                self.dataset_combo.setCurrentIndex(index)
+                return
+
+    def _apply_search_preset(self, preset):
+        """Apply a search preset to the dock controls."""
+        if not preset:
+            return
+        self._select_dataset_from_preset(preset)
+        self.bbox_input.setText(preset.get("bbox", ""))
+        temporal = preset.get("temporal", {})
+        start = QDate.fromString(temporal.get("start", ""), "yyyy-MM-dd")
+        end = QDate.fromString(temporal.get("end", ""), "yyyy-MM-dd")
+        if start.isValid():
+            self.start_date.setDate(start)
+        if end.isValid():
+            self.end_date.setDate(end)
+        self.max_items_spin.setValue(int(preset.get("max_items", 50) or 50))
+
+        advanced = preset.get("advanced", {})
+        self.advanced_check.setChecked(bool(advanced.get("enabled", False)))
+        self.cloud_min_spin.setValue(int(advanced.get("cloud_min", 0) or 0))
+        self.cloud_max_spin.setValue(int(advanced.get("cloud_max", 100) or 100))
+        day_night = advanced.get("day_night")
+        for index in range(self.daynight_combo.count()):
+            if self.daynight_combo.itemData(index) == day_night:
+                self.daynight_combo.setCurrentIndex(index)
+                break
+        self.provider_input.setText(advanced.get("provider", "") or "")
+        self.version_input.setText(advanced.get("version", "") or "")
+        self.granule_id_input.setText(advanced.get("granule_id", "") or "")
+        self.orbit_min_spin.setValue(int(advanced.get("orbit_min", 0) or 0))
+        self.orbit_max_spin.setValue(int(advanced.get("orbit_max", 0) or 0))
+        self._log(f"Loaded search preset: {preset.get('name', 'recent search')}")
+
+    def _load_selected_preset(self):
+        """Load the selected saved search preset."""
+        self._apply_search_preset(self.preset_combo.currentData())
+
+    def _load_selected_recent(self):
+        """Load the selected recent search."""
+        self._apply_search_preset(self.recent_combo.currentData())
+
+    def _record_recent_search(self):
+        """Record current search parameters in the recent-search list."""
+        try:
+            record_recent_search(
+                self.settings,
+                self._current_search_preset("Recent Search"),
+            )
+            self._load_recent_into_combo()
+        except Exception as e:
+            self._log(f"Could not record recent search: {e}", error=True)
 
     def _populate_dataset_combo(self, items):
         """Populate dataset combo while preserving row metadata as item data."""
@@ -1132,17 +1572,19 @@ class EarthdataDockWidget(QDockWidget):
         self._on_dataset_changed(self.dataset_combo.currentIndex())
 
     def _select_default_dataset(self):
-        """Select the default HLSL30 collection, preferring the newer duplicate."""
-        hlsl30_indices = [
-            index
-            for index in range(self.dataset_combo.count())
-            if (self.dataset_combo.itemData(index) or {}).get("short_name") == "HLSL30"
-        ]
-        if hlsl30_indices:
-            default_index = (
-                hlsl30_indices[1] if len(hlsl30_indices) > 1 else hlsl30_indices[0]
-            )
-            self.dataset_combo.setCurrentIndex(default_index)
+        """Select the default HLSL30 collection by concept ID."""
+        default_concept_id = "C2021957657-LPCLOUD"
+        fallback_index = -1
+        for index in range(self.dataset_combo.count()):
+            item = self.dataset_combo.itemData(index) or {}
+            if item.get("concept_id") == default_concept_id:
+                self.dataset_combo.setCurrentIndex(index)
+                return
+            if fallback_index < 0 and item.get("short_name") == "HLSL30":
+                fallback_index = index
+
+        if fallback_index >= 0:
+            self.dataset_combo.setCurrentIndex(fallback_index)
 
     def _on_catalog_loaded(self, df, items):
         """Handle catalog loaded."""
@@ -1228,6 +1670,9 @@ class EarthdataDockWidget(QDockWidget):
         self.display_btn.setEnabled(False)
         self.download_btn.setEnabled(False)
         self.zoom_footprints_btn.setEnabled(False)
+        self.export_csv_btn.setEnabled(False)
+        self.export_geojson_btn.setEnabled(False)
+        self.details_text.clear()
         self.cog_list.clear()
         self.cog_list.setEnabled(False)
         self.cog_mode_combo.setEnabled(False)
@@ -1492,6 +1937,7 @@ class EarthdataDockWidget(QDockWidget):
             self._log(f"Searching {dataset_label} by concept-id...")
         else:
             self._log(f"Searching {short_name}...")
+        self._record_recent_search()
 
         # Start search worker
         self._search_worker = DataSearchWorker(
@@ -1507,6 +1953,8 @@ class EarthdataDockWidget(QDockWidget):
             granule_id=granule_id,
             orbit_number=orbit_number,
         )
+        if self.settings.value("NASAEarthdata/debug", False, type=bool):
+            self._log(f"Search kwargs: {self._search_worker._build_search_kwargs()}")
         self._search_worker.finished.connect(self._on_search_finished)
         self._search_worker.error.connect(self._on_search_error)
         self._search_worker.progress.connect(self._log)
@@ -1622,6 +2070,9 @@ class EarthdataDockWidget(QDockWidget):
         self.display_btn.setEnabled(True)
         self.download_btn.setEnabled(True)
         self.zoom_footprints_btn.setEnabled(True)
+        self.export_csv_btn.setEnabled(True)
+        self.export_geojson_btn.setEnabled(True)
+        self._update_granule_details()
 
     def _on_search_error(self, error_msg):
         """Handle search error."""
@@ -1712,8 +2163,9 @@ class EarthdataDockWidget(QDockWidget):
                 QgsProject.instance().addMapLayer(layer)
                 self._footprints_layer = layer
 
-                # Zoom to footprints with proper CRS handling
-                self._zoom_to_footprints()
+                if self.settings.value("NASAEarthdata/auto_zoom", True, type=bool):
+                    # Zoom to footprints with proper CRS handling
+                    self._zoom_to_footprints()
 
                 self._log("Footprints added to map")
             else:
@@ -1910,6 +2362,7 @@ class EarthdataDockWidget(QDockWidget):
             self._clear_rgb_channel_combos()
 
         self._sync_footprint_selection_from_table()
+        self._update_granule_details()
 
     def _get_result_index_for_table_row(self, table_row):
         """Map current table row (after sorting) to original search result index."""
@@ -1942,6 +2395,108 @@ class EarthdataDockWidget(QDockWidget):
 
         # Preserve order while removing duplicates.
         return list(dict.fromkeys(indices))
+
+    def _first_selected_result_index(self):
+        """Return the first selected result index, if any."""
+        selected = self._get_selected_result_indices()
+        if selected:
+            return selected[0]
+        current_row = self.results_table.currentRow()
+        if current_row >= 0:
+            return self._get_result_index_for_table_row(current_row)
+        return -1
+
+    def _update_granule_details(self):
+        """Update the selected-granule detail inspector."""
+        if not self._search_results:
+            self.details_text.clear()
+            return
+
+        result_index = self._first_selected_result_index()
+        if result_index < 0 or result_index >= len(self._search_results):
+            self.details_text.setPlainText("Select a result to inspect metadata.")
+            return
+
+        granule = self._search_results[result_index]
+        dataset_item = self.dataset_combo.currentData() or {}
+        row = granule_export_row(granule, result_index, dataset_item)
+        links = granule_links(granule)
+        cog_links = [link for link in links if link in row.get("cog_links", "")]
+        lines = [
+            f"Native ID: {row.get('native_id', '')}",
+            f"Dataset: {row.get('dataset_short_name', '')}",
+            f"Concept ID: {row.get('dataset_concept_id', '')}",
+            f"Provider: {row.get('provider') or row.get('dataset_provider', '')}",
+            f"Version: {row.get('dataset_version', '')}",
+            f"Temporal Start: {row.get('temporal_start', '')}",
+            f"Temporal End: {row.get('temporal_end', '')}",
+            f"Size: {row.get('size_display', '')}",
+            f"COG/TIFF Links: {len(cog_links)}",
+            "",
+            "Links:",
+        ]
+        lines.extend(links or ["No links available"])
+        self.details_text.setPlainText("\n".join(str(line) for line in lines))
+
+    def _export_rows(self):
+        """Return export rows for all current results."""
+        return granules_to_export_rows(
+            self._search_results or [], self.dataset_combo.currentData() or {}
+        )
+
+    def _export_results_csv(self):
+        """Export current result metadata to CSV."""
+        if not self._search_results:
+            QMessageBox.information(
+                self, "Export Results", "No search results to export."
+            )
+            return
+
+        default_path = str(workflow_dir(self.settings) / "earthdata_results.csv")
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export NASA Earthdata Results CSV",
+            default_path,
+            "CSV Files (*.csv)",
+        )
+        if not file_path:
+            return
+
+        try:
+            write_results_csv(file_path, self._export_rows())
+            self._log(f"Exported result metadata: {file_path}")
+            self._notify_success("NASA Earthdata", "Exported result metadata to CSV")
+        except Exception as e:
+            QMessageBox.critical(self, "Export CSV", f"Failed to export:\n{e}")
+
+    def _export_results_geojson(self):
+        """Export current result footprints and metadata to GeoJSON."""
+        if not self._search_results:
+            QMessageBox.information(
+                self, "Export Results", "No search results to export."
+            )
+            return
+
+        default_path = str(workflow_dir(self.settings) / "earthdata_results.geojson")
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export NASA Earthdata Results GeoJSON",
+            default_path,
+            "GeoJSON Files (*.geojson *.json)",
+        )
+        if not file_path:
+            return
+
+        try:
+            write_results_geojson(file_path, self._export_rows(), self._search_gdf)
+            layer = QgsVectorLayer(file_path, "NASA Earthdata Exported Results", "ogr")
+            if layer.isValid():
+                layer.setCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
+                QgsProject.instance().addMapLayer(layer)
+            self._log(f"Exported result footprints: {file_path}")
+            self._notify_success("NASA Earthdata", "Exported result footprints")
+        except Exception as e:
+            QMessageBox.critical(self, "Export GeoJSON", f"Failed to export:\n{e}")
 
     def _sync_footprint_selection_from_table(self):
         """Highlight footprint features matching selected table rows."""
@@ -2043,14 +2598,66 @@ class EarthdataDockWidget(QDockWidget):
         if logical_index in (1, 2) and not self._adjusting_results_columns:
             QTimer.singleShot(0, self._fit_results_columns_to_width)
 
+    def _set_default_download_column_widths(self):
+        """Set initial queue column widths and make Granule fill remaining space."""
+        if self._adjusting_download_columns:
+            return
+
+        self._adjusting_download_columns = True
+        try:
+            self.download_queue_table.setColumnWidth(1, 80)
+            self.download_queue_table.setColumnWidth(2, 130)
+            self.download_queue_table.setColumnWidth(3, 90)
+        finally:
+            self._adjusting_download_columns = False
+
+        self._fit_download_columns_to_width()
+
+    def _fit_download_columns_to_width(self):
+        """Make the Granule column fill leftover queue table width."""
+        if self._adjusting_download_columns:
+            return
+
+        viewport_width = self.download_queue_table.viewport().width()
+        if viewport_width <= 0:
+            viewport_width = self.download_queue_table.width()
+        if viewport_width <= 0:
+            return
+
+        header = self.download_queue_table.horizontalHeader()
+        min_width = max(45, header.minimumSectionSize())
+        status_width = max(min_width, self.download_queue_table.columnWidth(1) or 80)
+        message_width = max(min_width, self.download_queue_table.columnWidth(2) or 130)
+        files_width = max(min_width, self.download_queue_table.columnWidth(3) or 90)
+        granule_width = max(
+            180, viewport_width - status_width - message_width - files_width
+        )
+
+        self._adjusting_download_columns = True
+        try:
+            self.download_queue_table.setColumnWidth(0, granule_width)
+        finally:
+            self._adjusting_download_columns = False
+
+    def _on_download_section_resized(self, logical_index, _old_size, _new_size):
+        """Keep Granule as the fill column when queue detail columns resize."""
+        if logical_index in (1, 2, 3) and not self._adjusting_download_columns:
+            QTimer.singleShot(0, self._fit_download_columns_to_width)
+
     def eventFilter(self, obj, event):
-        """Keep results columns fitted when the table viewport changes size."""
+        """Keep table columns fitted when viewports change size."""
         if (
             hasattr(self, "results_table")
             and obj in (self.results_table, self.results_table.viewport())
             and event.type() == QEvent.Type.Resize
         ):
             QTimer.singleShot(0, self._fit_results_columns_to_width)
+        if (
+            hasattr(self, "download_queue_table")
+            and obj in (self.download_queue_table, self.download_queue_table.viewport())
+            and event.type() == QEvent.Type.Resize
+        ):
+            QTimer.singleShot(0, self._fit_download_columns_to_width)
         return super().eventFilter(obj, event)
 
     def _sort_cog_links(self, cog_links):
@@ -2217,6 +2824,81 @@ class EarthdataDockWidget(QDockWidget):
             ]
         return self._search_results  # Return all if none selected
 
+    def _populate_download_queue(self, granules):
+        """Populate the download queue table."""
+        self.download_queue_table.setRowCount(len(granules or []))
+        for index, granule in enumerate(granules or []):
+            native_id = granule_native_id(granule, f"Item {index + 1}")
+            values = [native_id, "queued", "", ""]
+            for column, value in enumerate(values):
+                item = QTableWidgetItem(str(value))
+                item.setToolTip(str(value))
+                self.download_queue_table.setItem(index, column, item)
+        self._fit_download_columns_to_width()
+
+    def _on_download_queue_update(self, row, status, message, files):
+        """Update one download queue row."""
+        if row < 0 or row >= self.download_queue_table.rowCount():
+            return
+        values = {
+            1: status,
+            2: message,
+            3: "\n".join(str(file_path) for file_path in files),
+        }
+        for column, value in values.items():
+            item = self.download_queue_table.item(row, column)
+            if item is None:
+                item = QTableWidgetItem()
+                self.download_queue_table.setItem(row, column, item)
+            item.setText(str(value))
+            item.setToolTip(str(value))
+
+    def _cancel_download(self):
+        """Cancel the active download queue."""
+        if self._download_worker is not None and self._download_worker.isRunning():
+            self._download_worker.cancel()
+            self.cancel_download_btn.setEnabled(False)
+            self._log("Cancelling download queue after the current item...")
+
+    def _retry_failed_downloads(self):
+        """Retry failed download queue items in the previous output folder."""
+        if not self._last_download_output_dir:
+            return
+
+        failed_indices = [
+            int(row.get("index"))
+            for row in self._last_download_rows
+            if row.get("status") == "failed"
+        ]
+        granules = [
+            self._last_download_granules[index]
+            for index in failed_indices
+            if 0 <= index < len(self._last_download_granules)
+        ]
+        if not granules:
+            self.retry_failed_btn.setEnabled(False)
+            return
+
+        self.download_btn.setEnabled(False)
+        self.cancel_download_btn.setEnabled(True)
+        self.retry_failed_btn.setEnabled(False)
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setRange(0, 100)
+        self._populate_download_queue(granules)
+        self._log(f"Retrying {len(granules)} failed download(s)...")
+
+        self._download_worker = DataDownloadWorker(
+            granules,
+            self._last_download_output_dir,
+            threads=self.settings.value("NASAEarthdata/download_threads", 1, type=int),
+            skip_existing=True,
+        )
+        self._download_worker.finished.connect(self._on_download_finished)
+        self._download_worker.error.connect(self._on_download_error)
+        self._download_worker.progress.connect(self._on_download_progress)
+        self._download_worker.queue_update.connect(self._on_download_queue_update)
+        self._download_worker.start()
+
     def _display_cog(self):
         """Display selected COG layers using a worker thread."""
         display_mode = self.cog_mode_combo.currentData() or "single"
@@ -2376,7 +3058,7 @@ class EarthdataDockWidget(QDockWidget):
 
         if added_count > 0:
             self._log(f"Added {added_count} COG layer(s)")
-            self.iface.messageBar().pushSuccess(
+            self._notify_success(
                 "NASA Earthdata", f"Added {added_count} COG layer(s) to the map"
             )
         else:
@@ -2444,15 +3126,26 @@ class EarthdataDockWidget(QDockWidget):
 
         # Disable UI during download
         self.download_btn.setEnabled(False)
+        self.cancel_download_btn.setEnabled(True)
+        self.retry_failed_btn.setEnabled(False)
         self.progress_bar.setVisible(True)
         self.progress_bar.setRange(0, 100)
         self._log(f"Downloading {len(granules)} granule(s) to {output_dir}...")
+        self._populate_download_queue(granules)
+        self._last_download_granules = list(granules)
+        self._last_download_output_dir = output_dir
 
         # Start download worker
-        self._download_worker = DataDownloadWorker(granules, output_dir)
+        self._download_worker = DataDownloadWorker(
+            granules,
+            output_dir,
+            threads=self.settings.value("NASAEarthdata/download_threads", 1, type=int),
+            skip_existing=True,
+        )
         self._download_worker.finished.connect(self._on_download_finished)
         self._download_worker.error.connect(self._on_download_error)
         self._download_worker.progress.connect(self._on_download_progress)
+        self._download_worker.queue_update.connect(self._on_download_queue_update)
         self._download_worker.start()
 
     def _on_download_progress(self, percent, message):
@@ -2460,12 +3153,18 @@ class EarthdataDockWidget(QDockWidget):
         self.progress_bar.setValue(percent)
         self._log(message)
 
-    def _on_download_finished(self, files):
+    def _on_download_finished(self, files, manifest, queue_rows):
         """Handle download completion."""
         self.download_btn.setEnabled(True)
+        self.cancel_download_btn.setEnabled(False)
         self.progress_bar.setVisible(False)
+        self._last_download_rows = queue_rows
 
-        self._log(f"Download complete! {len(files)} file(s) downloaded.")
+        failed_count = len([row for row in queue_rows if row.get("status") == "failed"])
+        self.retry_failed_btn.setEnabled(failed_count > 0)
+        self._log(
+            f"Download complete! {len(files)} file(s) available. Manifest: {manifest}"
+        )
 
         # Offer to add downloaded files to map
         if files:
@@ -2488,10 +3187,12 @@ class EarthdataDockWidget(QDockWidget):
                         if layer.isValid():
                             QgsProject.instance().addMapLayer(layer)
                             self._log(f"Added: {layer_name}")
+        self._notify_success("NASA Earthdata", "Download queue complete")
 
     def _on_download_error(self, error_msg):
         """Handle download error."""
         self.download_btn.setEnabled(True)
+        self.cancel_download_btn.setEnabled(False)
         self.progress_bar.setVisible(False)
         self._log(f"Download error: {error_msg}", error=True)
 
@@ -2550,6 +3251,15 @@ class EarthdataDockWidget(QDockWidget):
         else:
             self.status_label.setText(message[:50])
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+
+    def _notify_success(self, title, message):
+        """Show a success notification when enabled."""
+        if not self.settings.value("NASAEarthdata/notifications", True, type=bool):
+            return
+        try:
+            self.iface.messageBar().pushSuccess(title, message)
+        except Exception:
+            pass  # nosec B110
 
     def closeEvent(self, event):
         """Handle dock widget close event."""

--- a/nasa_earthdata/metadata.txt
+++ b/nasa_earthdata/metadata.txt
@@ -25,7 +25,7 @@ about=NASA Earthdata Plugin for QGIS enables searching, visualizing, and downloa
 tracker=https://github.com/opengeos/qgis-nasa-earthdata-plugin/issues
 repository=https://github.com/opengeos/qgis-nasa-earthdata-plugin
 
-hasProcessingProvider=no
+hasProcessingProvider=yes
 
 tags=nasa, earthdata, satellite, remote sensing, COG, cloud optimized geotiff, download, visualization, GEDI, MODIS, Landsat
 
@@ -38,6 +38,7 @@ deprecated=False
 
 changelog=
     0.8.0
+        - Add saved searches, recent searches, result export, granule details, download queue, and Processing provider
         - Improve Earthdata search panel dataset selection, COG display, and layout
         - Add RGB COG channel selection and streamed COG visualization improvements
         - Add bounding box drawing tool and resizable/adaptive search result columns

--- a/nasa_earthdata/nasa_earthdata.py
+++ b/nasa_earthdata/nasa_earthdata.py
@@ -34,6 +34,7 @@ class NASAEarthdata:
         self._earthdata_dock = None
         self._settings_dock = None
         self._deps_signal_connected = False
+        self._processing_provider = None
 
     def add_action(
         self,
@@ -168,6 +169,8 @@ class NASAEarthdata:
             parent=self.iface.mainWindow(),
         )
 
+        self._register_processing_provider()
+
     def unload(self):
         """Remove the plugin menu item and icon from QGIS GUI."""
         # Remove dock widgets
@@ -189,9 +192,49 @@ class NASAEarthdata:
         if self.toolbar:
             del self.toolbar
 
+        self._unregister_processing_provider()
+
         # Remove menu
         if self.menu:
             self.menu.deleteLater()
+
+    def _register_processing_provider(self):
+        """Register QGIS Processing provider when Processing is available."""
+        if self._processing_provider is not None:
+            return
+        try:
+            from qgis.core import QgsApplication
+
+            from .processing.provider import NASAEarthdataProcessingProvider
+
+            registry = QgsApplication.processingRegistry()
+            if registry is None:
+                return
+            self._processing_provider = NASAEarthdataProcessingProvider()
+            registry.addProvider(self._processing_provider)
+        except Exception as exc:
+            print(
+                f"NASA Earthdata: could not register Processing provider: {exc}",
+                file=sys.stderr,
+            )
+            self._processing_provider = None
+
+    def _unregister_processing_provider(self):
+        """Unregister QGIS Processing provider."""
+        if self._processing_provider is None:
+            return
+        try:
+            from qgis.core import QgsApplication
+
+            registry = QgsApplication.processingRegistry()
+            if registry is not None:
+                registry.removeProvider(self._processing_provider)
+        except Exception as exc:
+            print(
+                f"NASA Earthdata: could not unregister Processing provider: {exc}",
+                file=sys.stderr,
+            )
+        self._processing_provider = None
 
     def toggle_earthdata_dock(self):
         """Toggle the NASA Earthdata dock widget visibility."""

--- a/nasa_earthdata/processing/__init__.py
+++ b/nasa_earthdata/processing/__init__.py
@@ -1,0 +1,5 @@
+"""QGIS Processing integration for NASA Earthdata."""
+
+from .provider import NASAEarthdataProcessingProvider
+
+__all__ = ["NASAEarthdataProcessingProvider"]

--- a/nasa_earthdata/processing/algorithms.py
+++ b/nasa_earthdata/processing/algorithms.py
@@ -1,0 +1,332 @@
+"""Processing algorithms for NASA Earthdata workflows.
+
+The classes in this module are intentionally conservative wrappers around the
+same earthaccess/GDAL behavior used by the dock. They also import cleanly in
+the repository's PyQt smoke-test stubs, where real QGIS Processing base classes
+are not available.
+"""
+
+import os
+
+from qgis.PyQt.QtCore import QCoreApplication
+
+try:
+    from qgis.core import (
+        QgsProcessing,
+        QgsProcessingAlgorithm,
+        QgsProcessingException,
+        QgsProcessingParameterBoolean,
+        QgsProcessingParameterEnum,
+        QgsProcessingParameterExtent,
+        QgsProcessingParameterFile,
+        QgsProcessingParameterFileDestination,
+        QgsProcessingParameterFolderDestination,
+        QgsProcessingParameterNumber,
+        QgsProcessingParameterString,
+    )
+except Exception:  # pragma: no cover - exercised by import smoke only
+    QgsProcessing = None
+    QgsProcessingAlgorithm = object
+    QgsProcessingException = RuntimeError
+    QgsProcessingParameterBoolean = None
+    QgsProcessingParameterEnum = None
+    QgsProcessingParameterExtent = None
+    QgsProcessingParameterFile = None
+    QgsProcessingParameterFileDestination = None
+    QgsProcessingParameterFolderDestination = None
+    QgsProcessingParameterNumber = None
+    QgsProcessingParameterString = None
+
+
+def _is_real_processing_base():
+    return isinstance(QgsProcessingAlgorithm, type)
+
+
+if not _is_real_processing_base():
+    QgsProcessingAlgorithm = object
+
+
+class _BaseAlgorithm(QgsProcessingAlgorithm):
+    """Common helpers for Processing algorithms."""
+
+    def tr(self, string):
+        return QCoreApplication.translate("NASAEarthdataProcessing", string)
+
+    def group(self):
+        return self.tr("NASA Earthdata")
+
+    def groupId(self):
+        return "nasa_earthdata"
+
+    def shortHelpString(self):
+        return self.tr("Runs a NASA Earthdata workflow from QGIS Processing.")
+
+    def _add_parameter(self, parameter):
+        if parameter is not None:
+            self.addParameter(parameter)
+
+    def _parameter_as_string(self, parameters, name, context):
+        if hasattr(self, "parameterAsString"):
+            return self.parameterAsString(parameters, name, context)
+        return parameters.get(name, "")
+
+    def _parameter_as_int(self, parameters, name, context):
+        if hasattr(self, "parameterAsInt"):
+            return self.parameterAsInt(parameters, name, context)
+        return int(parameters.get(name, 0) or 0)
+
+    def _parameter_as_bool(self, parameters, name, context):
+        if hasattr(self, "parameterAsBool"):
+            return self.parameterAsBool(parameters, name, context)
+        return bool(parameters.get(name, False))
+
+    def _parameter_as_file_output(self, parameters, name, context):
+        if hasattr(self, "parameterAsFileOutput"):
+            return self.parameterAsFileOutput(parameters, name, context)
+        return parameters.get(name, "")
+
+
+class SearchEarthdataAlgorithm(_BaseAlgorithm):
+    SHORT_NAME = "SHORT_NAME"
+    CONCEPT_ID = "CONCEPT_ID"
+    BBOX = "BBOX"
+    START_DATE = "START_DATE"
+    END_DATE = "END_DATE"
+    MAX_ITEMS = "MAX_ITEMS"
+    OUTPUT = "OUTPUT"
+
+    def name(self):
+        return "search_nasa_earthdata"
+
+    def displayName(self):
+        return self.tr("Search NASA Earthdata")
+
+    def createInstance(self):
+        return SearchEarthdataAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self._add_parameter(QgsProcessingParameterString(self.SHORT_NAME, "Short name"))
+        self._add_parameter(
+            QgsProcessingParameterString(self.CONCEPT_ID, "Concept ID", optional=True)
+        )
+        self._add_parameter(
+            QgsProcessingParameterString(
+                self.BBOX, "Bounding box xmin,ymin,xmax,ymax", optional=True
+            )
+        )
+        self._add_parameter(QgsProcessingParameterString(self.START_DATE, "Start date"))
+        self._add_parameter(QgsProcessingParameterString(self.END_DATE, "End date"))
+        self._add_parameter(
+            QgsProcessingParameterNumber(
+                self.MAX_ITEMS,
+                "Maximum items",
+                type=QgsProcessingParameterNumber.Integer,
+                defaultValue=50,
+                minValue=1,
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                "Result footprints GeoJSON",
+                fileFilter="GeoJSON files (*.geojson)",
+                optional=True,
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from nasa_earthdata.dialogs.earthdata_dock import DataSearchWorker
+
+        short_name = self._parameter_as_string(parameters, self.SHORT_NAME, context)
+        concept_id = self._parameter_as_string(parameters, self.CONCEPT_ID, context)
+        bbox_text = self._parameter_as_string(parameters, self.BBOX, context)
+        start_date = self._parameter_as_string(parameters, self.START_DATE, context)
+        end_date = self._parameter_as_string(parameters, self.END_DATE, context)
+        max_items = self._parameter_as_int(parameters, self.MAX_ITEMS, context)
+
+        bbox = None
+        if bbox_text:
+            parts = [float(item.strip()) for item in bbox_text.split(",")]
+            if len(parts) != 4:
+                raise QgsProcessingException("Bounding box must have 4 values")
+            bbox = tuple(parts)
+        temporal = (start_date, end_date) if start_date and end_date else None
+
+        worker = DataSearchWorker(short_name, concept_id, bbox, temporal, max_items)
+        kwargs = worker._build_search_kwargs()
+        if feedback:
+            feedback.pushInfo(f"Searching NASA Earthdata with {kwargs}")
+
+        from nasa_earthdata.core.venv_manager import import_earthaccess
+        from nasa_earthdata.core.workflows import (
+            granules_to_export_rows,
+            write_results_geojson,
+        )
+
+        earthaccess = import_earthaccess()
+        granules = earthaccess.search_data(count=max_items, **kwargs)
+        output = self._parameter_as_file_output(parameters, self.OUTPUT, context)
+        if output:
+            rows = granules_to_export_rows(
+                granules,
+                {"short_name": short_name, "concept_id": concept_id},
+            )
+            write_results_geojson(output, rows, None)
+        return {self.OUTPUT: output, "COUNT": len(granules)}
+
+
+class DownloadGranulesAlgorithm(_BaseAlgorithm):
+    GRANULES_JSON = "GRANULES_JSON"
+    OUTPUT_FOLDER = "OUTPUT_FOLDER"
+    SKIP_EXISTING = "SKIP_EXISTING"
+
+    def name(self):
+        return "download_nasa_earthdata_granules"
+
+    def displayName(self):
+        return self.tr("Download NASA Earthdata Granules")
+
+    def createInstance(self):
+        return DownloadGranulesAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self._add_parameter(
+            QgsProcessingParameterFile(
+                self.GRANULES_JSON,
+                "Granules JSON exported from earthaccess",
+                behavior=QgsProcessingParameterFile.File,
+                extension="json",
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterFolderDestination(
+                self.OUTPUT_FOLDER, "Download folder"
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterBoolean(
+                self.SKIP_EXISTING, "Skip existing files", defaultValue=True
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        import json
+
+        from nasa_earthdata.core.venv_manager import import_earthaccess
+
+        granules_json = self._parameter_as_string(
+            parameters, self.GRANULES_JSON, context
+        )
+        output_folder = self._parameter_as_string(
+            parameters, self.OUTPUT_FOLDER, context
+        )
+        with open(granules_json, "r", encoding="utf-8") as f:
+            granules = json.load(f)
+        earthaccess = import_earthaccess()
+        files = earthaccess.download(granules, local_path=output_folder)
+        return {
+            "FILES": [str(path) for path in files or []],
+            self.OUTPUT_FOLDER: output_folder,
+        }
+
+
+class AddFootprintsAlgorithm(_BaseAlgorithm):
+    INPUT = "INPUT"
+    OUTPUT = "OUTPUT"
+
+    def name(self):
+        return "add_nasa_earthdata_footprints"
+
+    def displayName(self):
+        return self.tr("Add Earthdata Footprints")
+
+    def createInstance(self):
+        return AddFootprintsAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self._add_parameter(
+            QgsProcessingParameterFile(
+                self.INPUT,
+                "Earthdata results GeoJSON",
+                behavior=QgsProcessingParameterFile.File,
+                extension="geojson",
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                "Footprints GeoJSON",
+                fileFilter="GeoJSON files (*.geojson)",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        source = self._parameter_as_string(parameters, self.INPUT, context)
+        output = self._parameter_as_file_output(parameters, self.OUTPUT, context)
+        if output and source != output:
+            import shutil
+
+            shutil.copyfile(source, output)
+        return {self.OUTPUT: output or source}
+
+
+class CreateRgbCogLayerAlgorithm(_BaseAlgorithm):
+    RED = "RED"
+    GREEN = "GREEN"
+    BLUE = "BLUE"
+    OUTPUT = "OUTPUT"
+
+    def name(self):
+        return "create_rgb_cog_layer"
+
+    def displayName(self):
+        return self.tr("Create RGB COG Layer")
+
+    def createInstance(self):
+        return CreateRgbCogLayerAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        for name, label in (
+            (self.RED, "Red COG URL/path"),
+            (self.GREEN, "Green COG URL/path"),
+            (self.BLUE, "Blue COG URL/path"),
+        ):
+            self._add_parameter(QgsProcessingParameterString(name, label))
+        self._add_parameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT, "RGB VRT", fileFilter="VRT files (*.vrt)"
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from osgeo import gdal
+
+        output = self._parameter_as_file_output(parameters, self.OUTPUT, context)
+        sources = [
+            self._parameter_as_string(parameters, self.RED, context),
+            self._parameter_as_string(parameters, self.GREEN, context),
+            self._parameter_as_string(parameters, self.BLUE, context),
+        ]
+        vrt_sources = [
+            f"/vsicurl/{source}" if source.lower().startswith("http") else source
+            for source in sources
+        ]
+        vrt = gdal.BuildVRT(
+            output,
+            vrt_sources,
+            options=gdal.BuildVRTOptions(separate=True),
+        )
+        if vrt is None:
+            raise QgsProcessingException("Could not build RGB VRT")
+        for band_index, color_interp in enumerate(
+            (gdal.GCI_RedBand, gdal.GCI_GreenBand, gdal.GCI_BlueBand),
+            start=1,
+        ):
+            band = vrt.GetRasterBand(band_index)
+            if band is not None:
+                band.SetColorInterpretation(color_interp)
+        vrt.FlushCache()
+        vrt = None
+        if not os.path.exists(output):
+            raise QgsProcessingException("RGB VRT was not written")
+        return {self.OUTPUT: output}

--- a/nasa_earthdata/processing/algorithms.py
+++ b/nasa_earthdata/processing/algorithms.py
@@ -15,6 +15,7 @@ try:
         QgsProcessing,
         QgsProcessingAlgorithm,
         QgsProcessingException,
+        QgsProcessingOutputNumber,
         QgsProcessingParameterBoolean,
         QgsProcessingParameterEnum,
         QgsProcessingParameterExtent,
@@ -28,6 +29,7 @@ except Exception:  # pragma: no cover - exercised by import smoke only
     QgsProcessing = None
     QgsProcessingAlgorithm = object
     QgsProcessingException = RuntimeError
+    QgsProcessingOutputNumber = None
     QgsProcessingParameterBoolean = None
     QgsProcessingParameterEnum = None
     QgsProcessingParameterExtent = None
@@ -65,6 +67,10 @@ class _BaseAlgorithm(QgsProcessingAlgorithm):
         if parameter is not None:
             self.addParameter(parameter)
 
+    def _add_output(self, output):
+        if output is not None and hasattr(self, "addOutput"):
+            self.addOutput(output)
+
     def _parameter_as_string(self, parameters, name, context):
         if hasattr(self, "parameterAsString"):
             return self.parameterAsString(parameters, name, context)
@@ -94,6 +100,7 @@ class SearchEarthdataAlgorithm(_BaseAlgorithm):
     END_DATE = "END_DATE"
     MAX_ITEMS = "MAX_ITEMS"
     OUTPUT = "OUTPUT"
+    COUNT = "COUNT"
 
     def name(self):
         return "search_nasa_earthdata"
@@ -133,6 +140,10 @@ class SearchEarthdataAlgorithm(_BaseAlgorithm):
                 optional=True,
             )
         )
+        if QgsProcessingOutputNumber is not None:
+            self._add_output(
+                QgsProcessingOutputNumber(self.COUNT, "Number of granules")
+            )
 
     def processAlgorithm(self, parameters, context, feedback):
         from nasa_earthdata.dialogs.earthdata_dock import DataSearchWorker
@@ -172,7 +183,7 @@ class SearchEarthdataAlgorithm(_BaseAlgorithm):
                 {"short_name": short_name, "concept_id": concept_id},
             )
             write_results_geojson(output, rows, None)
-        return {self.OUTPUT: output, "COUNT": len(granules)}
+        return {self.OUTPUT: output, self.COUNT: len(granules)}
 
 
 class DownloadGranulesAlgorithm(_BaseAlgorithm):
@@ -213,6 +224,7 @@ class DownloadGranulesAlgorithm(_BaseAlgorithm):
         import json
 
         from nasa_earthdata.core.venv_manager import import_earthaccess
+        from nasa_earthdata.core.workflows import likely_existing_download_files
 
         granules_json = self._parameter_as_string(
             parameters, self.GRANULES_JSON, context
@@ -220,12 +232,32 @@ class DownloadGranulesAlgorithm(_BaseAlgorithm):
         output_folder = self._parameter_as_string(
             parameters, self.OUTPUT_FOLDER, context
         )
+        skip_existing = self._parameter_as_bool(parameters, self.SKIP_EXISTING, context)
         with open(granules_json, "r", encoding="utf-8") as f:
             granules = json.load(f)
-        earthaccess = import_earthaccess()
-        files = earthaccess.download(granules, local_path=output_folder)
+
+        skipped_files = []
+        if skip_existing:
+            pending = []
+            for granule in granules:
+                existing = likely_existing_download_files(granule, output_folder)
+                if existing:
+                    skipped_files.extend(existing)
+                else:
+                    pending.append(granule)
+            if feedback and skipped_files:
+                feedback.pushInfo(
+                    f"Skipping {len(granules) - len(pending)} granule(s) with "
+                    f"existing files in {output_folder}"
+                )
+            granules = pending
+
+        files = []
+        if granules:
+            earthaccess = import_earthaccess()
+            files = earthaccess.download(granules, local_path=output_folder) or []
         return {
-            "FILES": [str(path) for path in files or []],
+            "FILES": [str(path) for path in files] + skipped_files,
             self.OUTPUT_FOLDER: output_folder,
         }
 

--- a/nasa_earthdata/processing/algorithms.py
+++ b/nasa_earthdata/processing/algorithms.py
@@ -55,10 +55,10 @@ class _BaseAlgorithm(QgsProcessingAlgorithm):
         return QCoreApplication.translate("NASAEarthdataProcessing", string)
 
     def group(self):
-        return self.tr("NASA Earthdata")
+        return self.tr("Tools")
 
     def groupId(self):
-        return "nasa_earthdata"
+        return "tools"
 
     def shortHelpString(self):
         return self.tr("Runs a NASA Earthdata workflow from QGIS Processing.")

--- a/nasa_earthdata/processing/provider.py
+++ b/nasa_earthdata/processing/provider.py
@@ -1,0 +1,50 @@
+"""QGIS Processing provider for NASA Earthdata."""
+
+from qgis.PyQt.QtGui import QIcon
+
+try:
+    from qgis.core import QgsProcessingProvider
+except Exception:  # pragma: no cover - import smoke fallback
+    QgsProcessingProvider = object
+
+if not isinstance(QgsProcessingProvider, type):
+    QgsProcessingProvider = object
+
+from .algorithms import (
+    AddFootprintsAlgorithm,
+    CreateRgbCogLayerAlgorithm,
+    DownloadGranulesAlgorithm,
+    SearchEarthdataAlgorithm,
+)
+
+
+class NASAEarthdataProcessingProvider(QgsProcessingProvider):
+    """Expose NASA Earthdata workflows in QGIS Processing."""
+
+    def __init__(self):
+        super().__init__()
+        self._fallback_algorithms = []
+
+    def id(self):
+        return "nasa_earthdata"
+
+    def name(self):
+        return "NASA Earthdata"
+
+    def longName(self):
+        return "NASA Earthdata"
+
+    def icon(self):
+        return QIcon()
+
+    def loadAlgorithms(self):
+        for algorithm in (
+            SearchEarthdataAlgorithm(),
+            DownloadGranulesAlgorithm(),
+            AddFootprintsAlgorithm(),
+            CreateRgbCogLayerAlgorithm(),
+        ):
+            if hasattr(self, "addAlgorithm"):
+                self.addAlgorithm(algorithm)
+            else:
+                self._fallback_algorithms.append(algorithm)

--- a/tests/test_earthdata_dock_core.py
+++ b/tests/test_earthdata_dock_core.py
@@ -1,5 +1,6 @@
 from nasa_earthdata.dialogs.earthdata_dock import (
     CatalogData,
+    CatalogLoadWorker,
     DataSearchWorker,
     EarthdataDockWidget,
     _compact_result_id,
@@ -73,6 +74,45 @@ def test_data_search_worker_prefers_concept_id_over_short_name():
     assert kwargs["bounding_box"] == (-123.0, 37.0, -122.0, 38.0)
     assert kwargs["temporal"] == ("2025-01-01", "2025-01-31")
     assert kwargs["provider"] == "LPCLOUD"
+
+
+def test_catalog_load_worker_accepts_custom_catalog_and_cache_settings(tmp_path):
+    worker = CatalogLoadWorker(
+        force_refresh=True,
+        catalog_url="https://example.test/catalog.tsv",
+        cache_dir=str(tmp_path),
+        cache_enabled=False,
+    )
+
+    assert worker.catalog_url == "https://example.test/catalog.tsv"
+    assert worker.cache_dir == tmp_path
+    assert worker.cache_enabled is False
+
+
+def test_default_dataset_prefers_hlsl30_concept_id():
+    class FakeCombo:
+        def __init__(self):
+            self.items = [
+                {"short_name": "HLSL30", "concept_id": "C3322682485-LPCLOUD"},
+                {"short_name": "HLSS30", "concept_id": "C2021957295-LPCLOUD"},
+                {"short_name": "HLSL30", "concept_id": "C2021957657-LPCLOUD"},
+            ]
+            self.selected = None
+
+        def count(self):
+            return len(self.items)
+
+        def itemData(self, index):
+            return self.items[index]
+
+        def setCurrentIndex(self, index):
+            self.selected = index
+
+    dock = type("Dock", (), {"dataset_combo": FakeCombo()})()
+
+    EarthdataDockWidget._select_default_dataset(dock)
+
+    assert dock.dataset_combo.selected == 2
 
 
 def test_rgb_channel_guess_uses_common_band_tokens():

--- a/tests/test_processing_provider.py
+++ b/tests/test_processing_provider.py
@@ -1,0 +1,8 @@
+from nasa_earthdata.processing.algorithms import SearchEarthdataAlgorithm
+
+
+def test_processing_algorithm_group_does_not_duplicate_provider_name():
+    algorithm = SearchEarthdataAlgorithm()
+
+    assert algorithm.group() == "Tools"
+    assert algorithm.groupId() == "tools"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,184 @@
+import csv
+import json
+
+from nasa_earthdata.core.workflows import (
+    build_search_preset,
+    delete_recent_search,
+    delete_search_preset,
+    granule_export_row,
+    likely_existing_download_files,
+    load_search_presets,
+    record_recent_search,
+    upsert_search_preset,
+    write_download_manifest,
+    write_results_csv,
+    write_results_geojson,
+)
+
+
+class FakeGranule(dict):
+    def __init__(self, links=None):
+        super().__init__(
+            {
+                "meta": {
+                    "native-id": "HLS.L30.T10SEG.2025131T184540.v2.0",
+                    "provider-id": "LPCLOUD",
+                },
+                "umm": {
+                    "GranuleUR": "HLS_GRANULE",
+                    "TemporalExtent": {
+                        "RangeDateTime": {
+                            "BeginningDateTime": "2025-05-11T18:45:40Z",
+                            "EndingDateTime": "2025-05-11T18:45:45Z",
+                        }
+                    },
+                    "DataGranule": {
+                        "ArchiveAndDistributionInformation": [
+                            {"SizeInBytes": 123456789}
+                        ],
+                    },
+                    "CollectionReference": {"ConceptID": "C2021957657-LPCLOUD"},
+                },
+            }
+        )
+        self._links = links or []
+
+    def data_links(self, access=None):
+        return self._links
+
+
+class FakeSettings:
+    def __init__(self):
+        self.values = {}
+
+    def value(self, key, default="", type=str):
+        value = self.values.get(key, default)
+        if type is str:
+            return str(value)
+        return value
+
+    def setValue(self, key, value):
+        self.values[key] = value
+
+    def sync(self):
+        pass
+
+
+def test_search_preset_serialization_round_trip(tmp_path):
+    preset = build_search_preset(
+        name="Bay Area HLS",
+        dataset_item={
+            "label": "HLSL30 (2.0)",
+            "short_name": "HLSL30",
+            "concept_id": "C2021957657-LPCLOUD",
+            "provider": "LPCLOUD",
+            "version": "2.0",
+            "title": "HLS Landsat",
+        },
+        bbox_text="-123,37,-122,38",
+        start_date="2025-01-01",
+        end_date="2025-01-31",
+        max_items=25,
+        advanced_options={"enabled": True, "cloud_max": 10},
+    )
+
+    path = tmp_path / "search_presets.json"
+    upsert_search_preset(path, preset)
+    loaded = load_search_presets(path)
+
+    assert loaded[0]["name"] == "Bay Area HLS"
+    assert loaded[0]["dataset"]["concept_id"] == "C2021957657-LPCLOUD"
+    assert loaded[0]["advanced"]["cloud_max"] == 10
+
+
+def test_delete_search_preset_removes_selected_name(tmp_path):
+    path = tmp_path / "search_presets.json"
+    first = build_search_preset("First", {}, "", "2025-01-01", "2025-01-02", 10)
+    second = build_search_preset("Second", {}, "", "2025-02-01", "2025-02-02", 10)
+    upsert_search_preset(path, first)
+    upsert_search_preset(path, second)
+
+    remaining = delete_search_preset(path, "First")
+
+    assert [preset["name"] for preset in remaining] == ["Second"]
+    assert [preset["name"] for preset in load_search_presets(path)] == ["Second"]
+
+
+def test_delete_recent_search_removes_selected_index():
+    settings = FakeSettings()
+    first = build_search_preset("First", {}, "", "2025-01-01", "2025-01-02", 10)
+    second = build_search_preset("Second", {}, "", "2025-02-01", "2025-02-02", 10)
+    record_recent_search(settings, first)
+    record_recent_search(settings, second)
+
+    remaining = delete_recent_search(settings, 0)
+
+    assert [preset["name"] for preset in remaining] == ["First"]
+
+
+def test_granule_export_row_contains_dataset_identity_and_links():
+    granule = FakeGranule(
+        [
+            "https://example.test/HLS.B04.tif",
+            "https://example.test/HLS.metadata.json",
+        ]
+    )
+
+    row = granule_export_row(
+        granule,
+        0,
+        {
+            "short_name": "HLSL30",
+            "concept_id": "C2021957657-LPCLOUD",
+            "provider": "LPCLOUD",
+            "version": "2.0",
+            "title": "HLS Landsat",
+        },
+    )
+
+    assert row["native_id"] == "HLS.L30.T10SEG.2025131T184540.v2.0"
+    assert row["dataset_short_name"] == "HLSL30"
+    assert row["dataset_concept_id"] == "C2021957657-LPCLOUD"
+    assert row["size_display"] == "123.5 MB"
+    assert row["cog_links"] == "https://example.test/HLS.B04.tif"
+
+
+def test_result_exports_write_stable_csv_and_geojson(tmp_path):
+    row = granule_export_row(FakeGranule(["https://example.test/HLS.B04.tif"]), 0)
+    csv_path = tmp_path / "earthdata_results.csv"
+    geojson_path = tmp_path / "earthdata_results.geojson"
+
+    write_results_csv(csv_path, [row])
+    write_results_geojson(geojson_path, [row], None)
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["native_id"] == "HLS.L30.T10SEG.2025131T184540.v2.0"
+
+    with open(geojson_path, encoding="utf-8") as f:
+        payload = json.load(f)
+    assert payload["type"] == "FeatureCollection"
+    assert payload["features"][0]["properties"]["result_idx"] == 0
+
+
+def test_download_helpers_detect_existing_files_and_write_manifest(tmp_path):
+    existing = tmp_path / "HLS.B04.tif"
+    existing.write_text("placeholder", encoding="utf-8")
+    granule = FakeGranule(["https://example.test/HLS.B04.tif?token=abc"])
+
+    assert likely_existing_download_files(granule, tmp_path) == [str(existing)]
+
+    manifest = tmp_path / "manifest.csv"
+    write_download_manifest(
+        manifest,
+        [
+            {
+                "index": 0,
+                "native_id": "HLS",
+                "status": "skipped",
+                "message": "Skipped existing",
+                "files": [str(existing)],
+            }
+        ],
+    )
+    assert "skipped" in manifest.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add workflow helpers for saved searches, recent searches, CSV result export, granule details, and a download queue (nasa_earthdata/core/workflows.py)
- Register a QGIS Processing provider that exposes the workflows as algorithms (nasa_earthdata/processing/)
- Wire the dock UI to the new workflow features and bump plugin version to 0.8.0

## Test plan
- [x] pre-commit run --all-files
- [x] tests/test_workflows.py and tests/test_earthdata_dock_core.py pass
- [ ] Load plugin in QGIS 3.28+ and verify saved/recent searches, export, and Processing toolbox entries
- [ ] Load plugin in QGIS 4.0 (Qt6) and verify the same flows