### PR TITLE
feat: add quicklook gallery, result filtering, and workflow tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The latest queue state is also written to `~/.qgis_nasa_earthdata/workflows/down
 
 ### AI Assistant Context
 
-If OpenGeoAgent is installed, click **AI Assistant** from the NASA Earthdata menu or **AI Context** in the result preview section. The plugin opens OpenGeoAgent and passes the current dataset, bbox, date range, result count, selected granules, and selected COG links when the OpenGeoAgent version exposes a context handoff method. If it does not, the same context is copied to the clipboard.
+If OpenGeoAgent is installed, click **AI Assistant** from the NASA Earthdata menu. The plugin opens OpenGeoAgent and passes the current dataset, bbox, date range, result count, selected granules, and selected COG links when the OpenGeoAgent version exposes a context handoff method.
 
 ### QGIS Processing
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ A QGIS plugin for searching, visualizing, and downloading NASA Earthdata product
 - **Cloud Optimized GeoTIFF (COG) Support**: Stream and visualize COG files directly without downloading
 - **Saved and Recent Searches**: Save reusable search presets, reload recent searches, and delete searches you no longer need
 - **Collection Discovery and Alerts**: Fetch live CMR collection metadata and check saved searches for newly available granules
-- **Quicklook and Citation Links**: Inspect browse/quicklook imagery and DOI/documentation links when granules expose them
+- **Quicklook Gallery and Citation Links**: Inspect inline browse/quicklook thumbnails, open a gallery dialog, and browse DOI/documentation links when granules expose them
 - **Granule Details and Export**: Inspect selected granule metadata and export search results to CSV, GeoJSON, raw JSON, STAC, or a reproducible workflow bundle
+- **Richer Result Filtering**: Filter result rows by granule ID, date, provider, cloud cover, day/night flag, size, or COG count
 - **Analysis-Ready VRTs**: Build RGB composites and normalized-difference index VRTs such as NDVI, NDWI, MNDWI, NDMI, and NBR from COG bands
 - **Download Queue**: Download selected granules with queue status, cancel/retry controls, skip-existing behavior, manifest output, and a persisted latest-queue snapshot
-- **QGIS Processing Tools**: Run NASA Earthdata search, download, footprint, RGB COG, and normalized-difference VRT workflows from the Processing Toolbox and Model Designer
+- **QGIS Processing Tools**: Run NASA Earthdata search, download, footprint, STAC export, workflow bundle, collection info, new-granule check, RGB COG, and normalized-difference VRT workflows from the Processing Toolbox and Model Designer
 - **Earthdata Login Integration**: Seamless authentication with NASA Earthdata Login credentials
 - **OpenGeoAgent Context Handoff**: Send the current dataset, bbox, selected granules, and COG links to OpenGeoAgent when available
 - **Settings Panel**: Configure credentials, download preferences, and plugin options
@@ -151,6 +152,7 @@ Alternatively, you can configure credentials via:
 2. Filter datasets by keyword (optional)
 3. Select a dataset from the dropdown. By default, the plugin selects `HLSL30` with concept ID `C2021957657-LPCLOUD` when it is available.
 4. Set the bounding box (or use current map extent)
+   - Click **Use Layer AOI** to use the active vector layer selection, or the active vector layer extent when no features are selected, as the search bounding box.
 5. Set the date range
 6. Click **Search**
 
@@ -179,8 +181,9 @@ Saved presets are stored in `~/.qgis_nasa_earthdata/workflows/search_presets.jso
 
 ### Inspecting and Exporting Results
 
+- Type in the **Filter** box above the result table to narrow results by ID, date, provider, cloud cover, day/night flag, size, or COG count.
 - Select a result row and expand **Granule Details** to view native ID, dataset identity, provider, temporal range, size, COG availability, and data links.
-- Expand **Quicklook and Citation** to view browse imagery and DOI/documentation links when present. Click **Open Quicklook** to open the first browse link in your browser.
+- Expand **Quicklook and Citation** to view inline browse imagery and DOI/documentation links when present. Click **Open Quicklook** to open the first browse link in your browser, or **Gallery** to compare quicklooks for selected rows.
 - Click **Export CSV** to write result metadata to `earthdata_results.csv`.
 - Click **Export GeoJSON** to write result metadata and footprints to `earthdata_results.geojson` and add the exported layer to the QGIS project.
 - Click **Export JSON** to write raw granule JSON that can be used by the Processing download tool.
@@ -210,6 +213,10 @@ The plugin registers a **NASA Earthdata** Processing provider with these algorit
 - **Search NASA Earthdata**: Search by short name or concept ID and optionally write result footprints to GeoJSON. This tool also supports cloud cover, day/night, provider, version, granule ID, orbit filters, and raw granule JSON output
 - **Download NASA Earthdata Granules**: Download granules from an exported Earthdata JSON input
 - **Add Earthdata Footprints**: Copy/export an Earthdata results GeoJSON as a Processing output
+- **Export NASA Earthdata STAC**: Convert exported granules JSON into a STAC ItemCollection
+- **Export NASA Earthdata Workflow Bundle**: Package search metadata, flat rows, raw granules, STAC content, and an optional download manifest path
+- **NASA Earthdata Collection Info**: Fetch CMR collection metadata summary by short name or concept ID
+- **Check New NASA Earthdata Granules**: Compare a fresh search against a baseline granules JSON and write only newly discovered granules
 - **Create RGB COG Layer**: Build an RGB VRT from red, green, and blue COG URLs or paths
 - **Create Normalized Difference VRT**: Build NDVI/NDWI/MNDWI/NDMI/NBR-style VRTs from two COG URLs or local rasters
 

--- a/nasa_earthdata/core/workflows.py
+++ b/nasa_earthdata/core/workflows.py
@@ -3,7 +3,7 @@
 import csv
 import json
 import os
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -358,13 +358,22 @@ def granule_related_urls(granule):
 
 
 def granule_quicklook_links(granule):
-    """Return likely browse/quicklook image URLs for a granule."""
+    """Return directly displayable browse/quicklook image URLs for a granule.
+
+    CMR entries can include matching ``s3://`` browse objects. Those are useful
+    for same-region cloud access but are not browser-displayable in QGIS, so do
+    not return them here.
+    """
     links = []
     for item in granule_related_urls(granule):
         url = str(item.get("URL", "")).strip()
         if not url:
             continue
         url_lower = url.lower()
+        parsed = urlsplit(url)
+        if parsed.scheme not in ("http", "https"):
+            continue
+        path_lower = parsed.path.lower()
         type_text = " ".join(
             str(item.get(key, ""))
             for key in ("Type", "Subtype", "Description", "Format")
@@ -373,7 +382,36 @@ def granule_quicklook_links(granule):
             "browse" in type_text
             or "quicklook" in type_text
             or "thumbnail" in type_text
-            or any(url_lower.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif"))
+            or any(
+                path_lower.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif")
+            )
+        ):
+            links.append(url)
+    return list(dict.fromkeys(links))
+
+
+def granule_inaccessible_quicklook_links(granule):
+    """Return browse/quicklook URLs that are not directly displayable in QGIS."""
+    links = []
+    for item in granule_related_urls(granule):
+        url = str(item.get("URL", "")).strip()
+        if not url:
+            continue
+        parsed = urlsplit(url)
+        if parsed.scheme in ("http", "https"):
+            continue
+        path_lower = parsed.path.lower()
+        type_text = " ".join(
+            str(item.get(key, ""))
+            for key in ("Type", "Subtype", "Description", "Format")
+        ).lower()
+        if (
+            "browse" in type_text
+            or "quicklook" in type_text
+            or "thumbnail" in type_text
+            or any(
+                path_lower.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif")
+            )
         ):
             links.append(url)
     return list(dict.fromkeys(links))

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -8,6 +8,7 @@ and downloading NASA Earthdata products in QGIS.
 import os
 import json
 import html
+import hashlib
 import platform
 import tempfile
 import time
@@ -72,6 +73,7 @@ from ..core.workflows import (
     download_queue_state_path,
     granule_export_row,
     granule_citation_links,
+    granule_inaccessible_quicklook_links,
     granule_links,
     granule_native_id,
     granule_quicklook_links,
@@ -2829,6 +2831,7 @@ class EarthdataDockWidget(QDockWidget):
             granule = self._search_results[result_index]
             native_id = granule_native_id(granule, f"Item {result_index + 1}")
             quicklooks = granule_quicklook_links(granule)
+            inaccessible_quicklooks = granule_inaccessible_quicklook_links(granule)
             citations = granule_citation_links(granule)
             all_quicklooks.extend(quicklooks)
             all_citations.extend(citations)
@@ -2838,13 +2841,16 @@ class EarthdataDockWidget(QDockWidget):
             if quicklooks:
                 html_parts.append("<div>")
                 for url in quicklooks[:4]:
-                    escaped = html.escape(url, quote=True)
-                    html_parts.append(
-                        f'<a href="{escaped}"><img src="{escaped}" '
-                        'height="96" style="margin:4px;"/></a>'
-                    )
+                    image_html = self._quicklook_img_html(url, 96)
+                    if image_html:
+                        html_parts.append(image_html)
                 html_parts.append("</div>")
                 html_parts.append(self._link_list_html(quicklooks, ""))
+            elif inaccessible_quicklooks:
+                html_parts.append(
+                    "<p>Browse objects are available only as non-browser storage links "
+                    "and cannot be previewed here.</p>"
+                )
             else:
                 html_parts.append("<p>No quicklook links found.</p>")
             if citations:
@@ -2880,6 +2886,41 @@ class EarthdataDockWidget(QDockWidget):
             return f"<p>{html.escape(empty_text)}</p>"
         items = "".join(f"<li>{self._link_html(link)}</li>" for link in links)
         return f"<ul>{items}</ul>"
+
+    def _cached_quicklook_image_src(self, url):
+        """Download an HTTPS quicklook to cache and return a local image URI."""
+        url = str(url or "").strip()
+        if not url.lower().startswith(("http://", "https://")):
+            return ""
+
+        suffix = Path(url.split("?", 1)[0]).suffix.lower()
+        if suffix not in (".jpg", ".jpeg", ".png", ".gif"):
+            suffix = ".jpg"
+
+        cache_dir = Path(tempfile.gettempdir()) / "nasa_earthdata_quicklooks"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        image_path = cache_dir / f"{digest}{suffix}"
+        if not image_path.exists():
+            try:
+                with https_only_urlopen(url, timeout=20) as resp:
+                    image_path.write_bytes(resp.read())
+            except Exception as e:
+                self._log(f"Could not load quicklook thumbnail: {e}", error=True)
+                return ""
+        return image_path.as_uri()
+
+    def _quicklook_img_html(self, url, height):
+        """Return HTML for a cached quicklook image linked to its source URL."""
+        src = self._cached_quicklook_image_src(url)
+        if not src:
+            return ""
+        escaped_url = html.escape(url, quote=True)
+        escaped_src = html.escape(src, quote=True)
+        return (
+            f'<a href="{escaped_url}"><img src="{escaped_src}" '
+            f'height="{int(height)}" style="margin:4px;"/></a>'
+        )
 
     def _open_selected_quicklook(self):
         """Open the first available quicklook link across selected granules."""
@@ -2918,11 +2959,10 @@ class EarthdataDockWidget(QDockWidget):
                 f"<h4>{html.escape(str(native_id))}</h4>"
             )
             for url in quicklooks[:6]:
-                escaped = html.escape(url, quote=True)
-                html_parts.append(
-                    f'<a href="{escaped}"><img src="{escaped}" '
-                    'height="180" style="margin:6px;"/></a>'
-                )
+                image_html = self._quicklook_img_html(url, 180)
+                if image_html:
+                    html_parts.append(image_html)
+            html_parts.append(self._link_list_html(quicklooks, ""))
             html_parts.append("</div>")
         html_parts.append("</body></html>")
         return "".join(html_parts)

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -17,7 +17,16 @@ import webbrowser
 from datetime import datetime
 from pathlib import Path
 
-from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal, QSettings, QDate, QEvent, QTimer
+from qgis.PyQt.QtCore import (
+    Qt,
+    QThread,
+    pyqtSignal,
+    QSettings,
+    QDate,
+    QEvent,
+    QTimer,
+    QItemSelectionModel,
+)
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
     QWidget,
@@ -1022,6 +1031,7 @@ class EarthdataDockWidget(QDockWidget):
         self._previous_map_tool = None
         self._adjusting_results_columns = False
         self._adjusting_download_columns = False
+        self._syncing_footprint_table_selection = False
         self._saved_presets = []
         self._recent_searches = []
         self._last_download_granules = []
@@ -1414,10 +1424,6 @@ class EarthdataDockWidget(QDockWidget):
         self.open_gallery_btn.setEnabled(False)
         self.open_gallery_btn.clicked.connect(self._open_quicklook_gallery)
         preview_btn_layout.addWidget(self.open_gallery_btn)
-        self.copy_context_btn = QPushButton("AI Context")
-        self.copy_context_btn.setEnabled(False)
-        self.copy_context_btn.clicked.connect(self._send_context_to_ai_assistant)
-        preview_btn_layout.addWidget(self.copy_context_btn)
         preview_btn_layout.addStretch()
         preview_layout.addLayout(preview_btn_layout)
         self.preview_section_check = self._add_collapsible_section(
@@ -1957,7 +1963,6 @@ class EarthdataDockWidget(QDockWidget):
         self.export_json_btn.setEnabled(False)
         self.export_stac_btn.setEnabled(False)
         self.export_bundle_btn.setEnabled(False)
-        self.copy_context_btn.setEnabled(False)
         self.open_quicklook_btn.setEnabled(False)
         self.open_gallery_btn.setEnabled(False)
         self.details_text.clear()
@@ -2432,7 +2437,6 @@ class EarthdataDockWidget(QDockWidget):
         self.export_json_btn.setEnabled(True)
         self.export_stac_btn.setEnabled(True)
         self.export_bundle_btn.setEnabled(True)
-        self.copy_context_btn.setEnabled(True)
         self._update_granule_details()
 
     def _on_search_error(self, error_msg):
@@ -2523,6 +2527,7 @@ class EarthdataDockWidget(QDockWidget):
 
                 QgsProject.instance().addMapLayer(layer)
                 self._footprints_layer = layer
+                self._connect_footprint_selection(layer)
 
                 if self.settings.value("NASAEarthdata/auto_zoom", True, type=bool):
                     # Zoom to footprints with proper CRS handling
@@ -2535,9 +2540,39 @@ class EarthdataDockWidget(QDockWidget):
         except Exception as e:
             self._log(f"Error adding footprints: {e}", error=True)
 
+    def _valid_layer_or_none(self, attr_name):
+        """Return a live QgsMapLayer wrapper, clearing stale deleted wrappers."""
+        layer = getattr(self, attr_name, None)
+        if layer is None:
+            return None
+        try:
+            if layer.isValid():
+                return layer
+        except RuntimeError:
+            pass
+        except Exception:
+            pass  # nosec B110
+        setattr(self, attr_name, None)
+        return None
+
+    def _connect_footprint_selection(self, layer):
+        """Connect footprint feature selection changes to the result table."""
+        try:
+            layer.selectionChanged.connect(self._on_footprint_selection_changed)
+        except Exception as e:
+            self._log(f"Could not connect footprint selection sync: {e}", error=True)
+
+    def _disconnect_footprint_selection(self, layer):
+        """Disconnect footprint feature selection changes when removing the layer."""
+        try:
+            layer.selectionChanged.disconnect(self._on_footprint_selection_changed)
+        except Exception:
+            pass  # nosec B110
+
     def _zoom_to_footprints(self):
         """Zoom the map canvas to selected footprints or all if none selected."""
-        if self._footprints_layer is None or not self._footprints_layer.isValid():
+        footprints_layer = self._valid_layer_or_none("_footprints_layer")
+        if footprints_layer is None:
             return
 
         if self._search_gdf is None:
@@ -2561,11 +2596,11 @@ class EarthdataDockWidget(QDockWidget):
                 self._log(f"Zooming to {len(indices)} selected footprint(s)")
             else:
                 # Zoom to all footprints
-                layer_extent = self._footprints_layer.extent()
+                layer_extent = footprints_layer.extent()
                 self._log("Zooming to all footprints")
 
             # Transform extent to map CRS if different
-            layer_crs = self._footprints_layer.crs()
+            layer_crs = footprints_layer.crs()
             canvas_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
 
             if layer_crs != canvas_crs:
@@ -2598,10 +2633,12 @@ class EarthdataDockWidget(QDockWidget):
     def _remove_footprints(self):
         """Remove footprints layer from map and clean up temporary file."""
         self._remove_selected_footprints()
-        if self._footprints_layer is not None:
+        footprints_layer = getattr(self, "_footprints_layer", None)
+        if footprints_layer is not None:
+            self._disconnect_footprint_selection(footprints_layer)
             try:
                 # Remove layer from project
-                QgsProject.instance().removeMapLayer(self._footprints_layer.id())
+                QgsProject.instance().removeMapLayer(footprints_layer.id())
             except Exception:
                 pass  # nosec B110
 
@@ -2644,11 +2681,10 @@ class EarthdataDockWidget(QDockWidget):
 
     def _remove_selected_footprints(self):
         """Remove the outline-only selected footprint overlay."""
-        if self._selected_footprints_layer is not None:
+        selected_layer = getattr(self, "_selected_footprints_layer", None)
+        if selected_layer is not None:
             try:
-                QgsProject.instance().removeMapLayer(
-                    self._selected_footprints_layer.id()
-                )
+                QgsProject.instance().removeMapLayer(selected_layer.id())
             except Exception:
                 pass  # nosec B110
             try:
@@ -2663,6 +2699,7 @@ class EarthdataDockWidget(QDockWidget):
             return
 
         try:
+            footprints_layer = self._valid_layer_or_none("_footprints_layer")
             from qgis.core import (
                 QgsFeature,
                 QgsFillSymbol,
@@ -2670,7 +2707,11 @@ class EarthdataDockWidget(QDockWidget):
                 QgsWkbTypes,
             )
 
-            geometry_name = QgsWkbTypes.displayString(self._footprints_layer.wkbType())
+            geometry_name = (
+                QgsWkbTypes.displayString(footprints_layer.wkbType())
+                if footprints_layer is not None
+                else "Polygon"
+            )
             if "Polygon" not in geometry_name:
                 geometry_name = "Polygon"
             selected_layer = QgsVectorLayer(
@@ -2723,7 +2764,8 @@ class EarthdataDockWidget(QDockWidget):
             self._clear_rgb_channel_combos()
             self._clear_index_combos()
 
-        self._sync_footprint_selection_from_table()
+        if not self._syncing_footprint_table_selection:
+            self._sync_footprint_selection_from_table()
         self._update_granule_details()
         self._update_quicklook_preview()
 
@@ -3023,25 +3065,6 @@ class EarthdataDockWidget(QDockWidget):
         if len(selected_indices) > 8:
             lines.append(f"...and {len(selected_indices) - 8} more selected granules")
         return "\n".join(lines)
-
-    def _send_context_to_ai_assistant(self):
-        """Open OpenGeoAgent and make current plugin context available."""
-        try:
-            plugin = getattr(self.iface, "_nasa_earthdata_plugin", None)
-            if plugin is not None and hasattr(plugin, "open_ai_assistant"):
-                plugin.open_ai_assistant(context=self.ai_context_summary())
-                return
-        except Exception:
-            pass  # nosec B110
-
-        clipboard = QApplication.clipboard()
-        if clipboard is not None:
-            clipboard.setText(self.ai_context_summary())
-        QMessageBox.information(
-            self,
-            "AI Context",
-            "Current NASA Earthdata context was copied to the clipboard.",
-        )
 
     def _export_rows(self):
         """Return export rows for all current results."""
@@ -3396,12 +3419,14 @@ class EarthdataDockWidget(QDockWidget):
 
     def _sync_footprint_selection_from_table(self):
         """Highlight footprint features matching selected table rows."""
-        if self._footprints_layer is None or not self._footprints_layer.isValid():
+        footprints_layer = self._valid_layer_or_none("_footprints_layer")
+        if footprints_layer is None:
             return
 
         try:
             selected_indices = set(self._get_selected_result_indices())
-            self._footprints_layer.removeSelection()
+            self._syncing_footprint_table_selection = True
+            footprints_layer.removeSelection()
             self._remove_selected_footprints()
 
             if not selected_indices:
@@ -3409,10 +3434,11 @@ class EarthdataDockWidget(QDockWidget):
                 return
 
             selected_features = []
-            field_names = [f.name() for f in self._footprints_layer.fields()]
+            selected_feature_ids = []
+            field_names = [f.name() for f in footprints_layer.fields()]
             has_result_idx_field = "result_idx" in field_names
 
-            for feature_pos, feature in enumerate(self._footprints_layer.getFeatures()):
+            for feature_pos, feature in enumerate(footprints_layer.getFeatures()):
                 if has_result_idx_field:
                     try:
                         feature_result_idx = int(feature["result_idx"])
@@ -3423,11 +3449,115 @@ class EarthdataDockWidget(QDockWidget):
 
                 if feature_result_idx in selected_indices:
                     selected_features.append(feature)
+                    selected_feature_ids.append(feature.id())
 
+            if selected_feature_ids:
+                footprints_layer.selectByIds(selected_feature_ids)
             self._add_selected_footprints_overlay(selected_features)
             self.iface.mapCanvas().refresh()
+        except RuntimeError as e:
+            if "wrapped C/C++ object" in str(e):
+                self._footprints_layer = None
+                self._remove_selected_footprints()
+                return
+            self._log(f"Error syncing footprint selection: {e}", error=True)
         except Exception as e:
             self._log(f"Error syncing footprint selection: {e}", error=True)
+        finally:
+            self._syncing_footprint_table_selection = False
+
+    def _result_indices_for_selected_footprints(self, footprints_layer):
+        """Return search result indices for selected footprint features."""
+        selected_feature_ids = set(footprints_layer.selectedFeatureIds())
+        if not selected_feature_ids:
+            return []
+
+        result_indices = []
+        field_names = [field.name() for field in footprints_layer.fields()]
+        has_result_idx_field = "result_idx" in field_names
+        for feature_pos, feature in enumerate(footprints_layer.getFeatures()):
+            if feature.id() not in selected_feature_ids:
+                continue
+            if has_result_idx_field:
+                try:
+                    result_idx = int(feature["result_idx"])
+                except Exception:
+                    result_idx = feature_pos
+            else:
+                result_idx = feature_pos
+            result_indices.append(result_idx)
+        return list(dict.fromkeys(result_indices))
+
+    def _table_rows_for_result_indices(self, result_indices):
+        """Return current table rows that correspond to stable result indices."""
+        wanted = set(result_indices)
+        rows = []
+        for row in range(self.results_table.rowCount()):
+            if self._get_result_index_for_table_row(row) in wanted:
+                rows.append(row)
+        return rows
+
+    def _select_table_rows_for_result_indices(self, result_indices):
+        """Select result table rows matching map-selected footprint features."""
+        rows = self._table_rows_for_result_indices(result_indices)
+        selection_model = self.results_table.selectionModel()
+        if selection_model is None:
+            return
+
+        self._syncing_footprint_table_selection = True
+        try:
+            selection_model.clearSelection()
+            if not rows:
+                return
+            flag_scope = getattr(
+                QItemSelectionModel, "SelectionFlag", QItemSelectionModel
+            )
+            select_rows = getattr(flag_scope, "Select") | getattr(flag_scope, "Rows")
+            for row in rows:
+                index = self.results_table.model().index(row, 0)
+                selection_model.select(index, select_rows)
+            first_row = rows[0]
+            self.results_table.setCurrentCell(first_row, 0)
+            first_item = self.results_table.item(first_row, 0)
+            if first_item is not None:
+                self.results_table.scrollToItem(first_item)
+        finally:
+            self._syncing_footprint_table_selection = False
+
+    def _on_footprint_selection_changed(self, *_args):
+        """Select result table rows when footprint features are selected on the map."""
+        if self._syncing_footprint_table_selection:
+            return
+        footprints_layer = self._valid_layer_or_none("_footprints_layer")
+        if footprints_layer is None:
+            return
+        try:
+            result_indices = self._result_indices_for_selected_footprints(
+                footprints_layer
+            )
+            self._select_table_rows_for_result_indices(result_indices)
+            self._remove_selected_footprints()
+            if result_indices:
+                selected_features = []
+                selected = set(result_indices)
+                for feature_pos, feature in enumerate(footprints_layer.getFeatures()):
+                    try:
+                        feature_result_idx = int(feature["result_idx"])
+                    except Exception:
+                        feature_result_idx = feature_pos
+                    if feature_result_idx in selected:
+                        selected_features.append(feature)
+                self._add_selected_footprints_overlay(selected_features)
+            self._update_granule_details()
+            self._update_quicklook_preview()
+        except RuntimeError as e:
+            if "wrapped C/C++ object" in str(e):
+                self._footprints_layer = None
+                self._remove_selected_footprints()
+                return
+            self._log(f"Error syncing footprint selection to table: {e}", error=True)
+        except Exception as e:
+            self._log(f"Error syncing footprint selection to table: {e}", error=True)
 
     def _on_header_double_clicked(self, logical_index):
         """Handle double-click on table header to toggle sort order."""

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -1130,6 +1130,12 @@ class EarthdataDockWidget(QDockWidget):
         self.use_extent_btn = QPushButton("Use Map Extent")
         self.use_extent_btn.clicked.connect(self._use_map_extent)
         bbox_btn_layout.addWidget(self.use_extent_btn)
+        self.use_layer_aoi_btn = QPushButton("Use Layer AOI")
+        self.use_layer_aoi_btn.setToolTip(
+            "Use the active vector layer selection, or the active layer extent, as the search bounding box"
+        )
+        self.use_layer_aoi_btn.clicked.connect(self._use_active_layer_aoi)
+        bbox_btn_layout.addWidget(self.use_layer_aoi_btn)
         self.draw_bbox_btn = QPushButton("Draw Bbox")
         self.draw_bbox_btn.setCheckable(True)
         self.draw_bbox_btn.toggled.connect(self._toggle_draw_bbox)
@@ -1326,9 +1332,24 @@ class EarthdataDockWidget(QDockWidget):
         results_layout = QVBoxLayout(results_group)
 
         # Results table
+        filter_layout = QHBoxLayout()
+        filter_layout.addWidget(QLabel("Filter:"))
+        self.result_filter_input = QLineEdit()
+        self.result_filter_input.setPlaceholderText(
+            "Filter results by ID, date, provider, cloud, day/night, or COG count..."
+        )
+        self.result_filter_input.textChanged.connect(self._filter_result_rows)
+        filter_layout.addWidget(self.result_filter_input, 1)
+        self.clear_result_filter_btn = QPushButton("Clear")
+        self.clear_result_filter_btn.clicked.connect(self.result_filter_input.clear)
+        filter_layout.addWidget(self.clear_result_filter_btn)
+        results_layout.addLayout(filter_layout)
+
         self.results_table = QTableWidget()
-        self.results_table.setColumnCount(3)
-        self.results_table.setHorizontalHeaderLabels(["ID", "Date", "Size"])
+        self.results_table.setColumnCount(7)
+        self.results_table.setHorizontalHeaderLabels(
+            ["ID", "Date", "Size", "Provider", "Cloud", "Day/Night", "COGs"]
+        )
         # Start with practical widths, but keep all columns user-resizable.
         results_header = self.results_table.horizontalHeader()
         results_header.setSectionsClickable(True)
@@ -1387,6 +1408,10 @@ class EarthdataDockWidget(QDockWidget):
         self.open_quicklook_btn.setEnabled(False)
         self.open_quicklook_btn.clicked.connect(self._open_selected_quicklook)
         preview_btn_layout.addWidget(self.open_quicklook_btn)
+        self.open_gallery_btn = QPushButton("Gallery")
+        self.open_gallery_btn.setEnabled(False)
+        self.open_gallery_btn.clicked.connect(self._open_quicklook_gallery)
+        preview_btn_layout.addWidget(self.open_gallery_btn)
         self.copy_context_btn = QPushButton("AI Context")
         self.copy_context_btn.setEnabled(False)
         self.copy_context_btn.clicked.connect(self._send_context_to_ai_assistant)
@@ -1919,6 +1944,8 @@ class EarthdataDockWidget(QDockWidget):
     def _clear_results(self):
         """Clear search results without resetting other settings."""
         self.results_table.setRowCount(0)
+        if hasattr(self, "result_filter_input"):
+            self.result_filter_input.clear()
         self.results_label.setText("No search performed yet")
         self.display_btn.setEnabled(False)
         self.download_btn.setEnabled(False)
@@ -1930,6 +1957,7 @@ class EarthdataDockWidget(QDockWidget):
         self.export_bundle_btn.setEnabled(False)
         self.copy_context_btn.setEnabled(False)
         self.open_quicklook_btn.setEnabled(False)
+        self.open_gallery_btn.setEnabled(False)
         self.details_text.clear()
         self.preview_text.clear()
         self.cog_list.clear()
@@ -1959,6 +1987,55 @@ class EarthdataDockWidget(QDockWidget):
 
         bbox_str = f"{extent.xMinimum():.4f}, {extent.yMinimum():.4f}, {extent.xMaximum():.4f}, {extent.yMaximum():.4f}"
         self.bbox_input.setText(bbox_str)
+
+    def _use_active_layer_aoi(self):
+        """Set bbox from the active vector layer selection or layer extent."""
+        try:
+            layer = self.iface.activeLayer()
+        except Exception:
+            layer = None
+        if layer is None:
+            QMessageBox.information(
+                self, "Use Layer AOI", "Select an active vector layer first."
+            )
+            return
+
+        if not isinstance(layer, QgsVectorLayer):
+            QMessageBox.information(
+                self, "Use Layer AOI", "The active layer must be a vector layer."
+            )
+            return
+
+        try:
+            selected_features = list(layer.selectedFeatures())
+        except Exception:
+            selected_features = []
+
+        if selected_features:
+            extent = selected_features[0].geometry().boundingBox()
+            for feature in selected_features[1:]:
+                extent.combineExtentWith(feature.geometry().boundingBox())
+            source = f"{len(selected_features)} selected feature(s)"
+        else:
+            extent = layer.extent()
+            source = "active layer extent"
+
+        try:
+            layer_crs = layer.crs()
+            if layer_crs.authid() != "EPSG:4326":
+                transform = QgsCoordinateTransform(
+                    layer_crs,
+                    QgsCoordinateReferenceSystem("EPSG:4326"),
+                    QgsProject.instance(),
+                )
+                extent = transform.transformBoundingBox(extent)
+            bbox_str = f"{extent.xMinimum():.4f}, {extent.yMinimum():.4f}, {extent.xMaximum():.4f}, {extent.yMaximum():.4f}"
+            self.bbox_input.setText(bbox_str)
+            self._log(f"Bounding box set from {source}: {layer.name()}")
+        except Exception as e:
+            QMessageBox.warning(
+                self, "Use Layer AOI", f"Could not use active layer AOI:\n{e}"
+            )
 
     def _extent_to_wgs84_bbox_text(self, extent):
         """Convert a map-canvas extent to formatted WGS84 bbox text."""
@@ -2245,32 +2322,29 @@ class EarthdataDockWidget(QDockWidget):
         self.results_table.setRowCount(len(results))
         for i, granule in enumerate(results):
             try:
-                native_id = granule.get("meta", {}).get("native-id", f"Item {i+1}")
-                # Get date from time range
-                time_start = (
-                    granule.get("umm", {})
-                    .get("TemporalExtent", {})
-                    .get("RangeDateTime", {})
-                    .get("BeginningDateTime", "N/A")
+                row = granule_export_row(
+                    granule, i, self.dataset_combo.currentData() or {}
                 )
-                if time_start != "N/A":
-                    time_start = time_start[:10]  # Just the date part
-
-                # Estimate size
-                size_display = "N/A"
-                size_bytes = 0  # For sorting
-                data_granule = granule.get("umm", {}).get("DataGranule", {})
-                if "ArchiveAndDistributionInformation" in data_granule:
-                    for info in data_granule["ArchiveAndDistributionInformation"]:
-                        if "SizeInBytes" in info:
-                            size_bytes = info["SizeInBytes"]
-                            if size_bytes > 1e9:
-                                size_display = f"{size_bytes / 1e9:.1f} GB"
-                            elif size_bytes > 1e6:
-                                size_display = f"{size_bytes / 1e6:.1f} MB"
-                            else:
-                                size_display = f"{size_bytes / 1e3:.1f} KB"
-                            break
+                native_id = row.get("native_id") or f"Item {i + 1}"
+                time_start = (row.get("temporal_start") or "N/A")[:10]
+                size_display = row.get("size_display") or "N/A"
+                size_bytes = row.get("size_bytes") or 0
+                provider = row.get("provider") or row.get("dataset_provider") or ""
+                cloud_cover = row.get("cloud_cover")
+                if cloud_cover in (None, ""):
+                    cloud_display = ""
+                    cloud_sort = -1
+                else:
+                    try:
+                        cloud_sort = float(cloud_cover)
+                        cloud_display = f"{cloud_sort:g}%"
+                    except (TypeError, ValueError):
+                        cloud_sort = -1
+                        cloud_display = str(cloud_cover)
+                day_night = row.get("day_night") or ""
+                cog_count = len(
+                    [link for link in row.get("cog_links", "").splitlines() if link]
+                )
 
                 # Create items with tooltips for full text
                 id_item = QTableWidgetItem(_compact_result_id(native_id))
@@ -2298,6 +2372,24 @@ class EarthdataDockWidget(QDockWidget):
                     Qt.ItemDataRole.UserRole, size_bytes
                 )  # Store raw value for sorting
                 self.results_table.setItem(i, 2, size_item)
+
+                provider_item = QTableWidgetItem(str(provider))
+                provider_item.setToolTip(str(provider))
+                self.results_table.setItem(i, 3, provider_item)
+
+                cloud_item = NumericTableWidgetItem(str(cloud_display))
+                cloud_item.setData(Qt.ItemDataRole.UserRole, cloud_sort)
+                cloud_item.setToolTip(str(cloud_display))
+                self.results_table.setItem(i, 4, cloud_item)
+
+                daynight_item = QTableWidgetItem(str(day_night))
+                daynight_item.setToolTip(str(day_night))
+                self.results_table.setItem(i, 5, daynight_item)
+
+                cogs_item = NumericTableWidgetItem(str(cog_count))
+                cogs_item.setData(Qt.ItemDataRole.UserRole, cog_count)
+                cogs_item.setToolTip(f"{cog_count} COG/TIFF link(s)")
+                self.results_table.setItem(i, 6, cogs_item)
             except Exception:
                 id_item = QTableWidgetItem(f"Item {i+1}")
                 id_item.setTextAlignment(
@@ -2318,10 +2410,13 @@ class EarthdataDockWidget(QDockWidget):
                 )
                 size_item.setData(Qt.ItemDataRole.UserRole, 0)  # Store 0 for N/A
                 self.results_table.setItem(i, 2, size_item)
+                for column in range(3, self.results_table.columnCount()):
+                    self.results_table.setItem(i, column, QTableWidgetItem(""))
 
         # Re-enable sorting after population
         self.results_table.setSortingEnabled(True)
         self._set_default_results_column_widths()
+        self._filter_result_rows()
 
         # Add footprints to map
         self._add_footprints(gdf)
@@ -2705,29 +2800,68 @@ class EarthdataDockWidget(QDockWidget):
         self.details_text.setPlainText("\n".join(str(line) for line in lines))
 
     def _update_quicklook_preview(self):
-        """Update quicklook/citation links for the selected granule."""
+        """Update quicklook/citation links for selected granules."""
         if not self._search_results:
             self.preview_text.clear()
             self.open_quicklook_btn.setEnabled(False)
+            self.open_gallery_btn.setEnabled(False)
             return
 
-        result_index = self._first_selected_result_index()
-        if result_index < 0 or result_index >= len(self._search_results):
+        selected_indices = self._get_selected_result_indices()
+        if not selected_indices:
+            first_index = self._first_selected_result_index()
+            selected_indices = [first_index] if first_index >= 0 else []
+        selected_indices = [
+            index
+            for index in selected_indices
+            if 0 <= index < len(self._search_results)
+        ]
+        if not selected_indices:
             self.preview_text.setPlainText("Select a result to inspect preview links.")
             self.open_quicklook_btn.setEnabled(False)
+            self.open_gallery_btn.setEnabled(False)
             return
 
-        granule = self._search_results[result_index]
-        quicklooks = granule_quicklook_links(granule)
-        citations = granule_citation_links(granule)
-        html_parts = [
-            "<h4>Quicklook / browse links</h4>",
-            self._link_list_html(quicklooks, "No quicklook links found."),
-            "<h4>Citation / documentation links</h4>",
-            self._link_list_html(citations, "No citation links found."),
-        ]
+        html_parts = ["<h4>Quicklook / browse gallery</h4>"]
+        all_quicklooks = []
+        all_citations = []
+        for result_index in selected_indices[:12]:
+            granule = self._search_results[result_index]
+            native_id = granule_native_id(granule, f"Item {result_index + 1}")
+            quicklooks = granule_quicklook_links(granule)
+            citations = granule_citation_links(granule)
+            all_quicklooks.extend(quicklooks)
+            all_citations.extend(citations)
+            html_parts.append(
+                f"<p><b>{html.escape(_compact_result_id(native_id))}</b></p>"
+            )
+            if quicklooks:
+                html_parts.append("<div>")
+                for url in quicklooks[:4]:
+                    escaped = html.escape(url, quote=True)
+                    html_parts.append(
+                        f'<a href="{escaped}"><img src="{escaped}" '
+                        'height="96" style="margin:4px;"/></a>'
+                    )
+                html_parts.append("</div>")
+                html_parts.append(self._link_list_html(quicklooks, ""))
+            else:
+                html_parts.append("<p>No quicklook links found.</p>")
+            if citations:
+                html_parts.append("<p>Citation / documentation:</p>")
+                html_parts.append(self._link_list_html(citations, ""))
+
+        if len(selected_indices) > 12:
+            html_parts.append(
+                f"<p>Showing previews for 12 of {len(selected_indices)} selected granules.</p>"
+            )
+        unique_citations = list(dict.fromkeys(all_citations))
+        if unique_citations:
+            html_parts.append("<h4>All Citation / documentation links</h4>")
+            html_parts.append(self._link_list_html(unique_citations, ""))
         self.preview_text.setHtml("".join(html_parts))
-        self.open_quicklook_btn.setEnabled(bool(quicklooks))
+        self.open_quicklook_btn.setEnabled(bool(all_quicklooks))
+        self.open_gallery_btn.setEnabled(bool(all_quicklooks))
 
     def _link_html(self, url, label=None):
         """Return an escaped external-link anchor for display widgets."""
@@ -2755,6 +2889,54 @@ class EarthdataDockWidget(QDockWidget):
         quicklooks = granule_quicklook_links(self._search_results[result_index])
         if quicklooks:
             webbrowser.open(quicklooks[0])
+
+    def _quicklook_gallery_html(self):
+        """Return an HTML quicklook gallery for selected or current results."""
+        if not self._search_results:
+            return "<p>No search results available.</p>"
+        selected_indices = self._get_selected_result_indices()
+        if not selected_indices:
+            selected_indices = list(range(min(24, len(self._search_results))))
+
+        html_parts = ["<html><body><h3>NASA Earthdata Quicklook Gallery</h3>"]
+        for result_index in selected_indices[:48]:
+            if result_index < 0 or result_index >= len(self._search_results):
+                continue
+            granule = self._search_results[result_index]
+            native_id = granule_native_id(granule, f"Item {result_index + 1}")
+            quicklooks = granule_quicklook_links(granule)
+            if not quicklooks:
+                continue
+            html_parts.append(
+                '<div style="margin-bottom:14px;">'
+                f"<h4>{html.escape(str(native_id))}</h4>"
+            )
+            for url in quicklooks[:6]:
+                escaped = html.escape(url, quote=True)
+                html_parts.append(
+                    f'<a href="{escaped}"><img src="{escaped}" '
+                    'height="180" style="margin:6px;"/></a>'
+                )
+            html_parts.append("</div>")
+        html_parts.append("</body></html>")
+        return "".join(html_parts)
+
+    def _open_quicklook_gallery(self):
+        """Open a scrollable dialog with selected quicklook images."""
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Quicklook Gallery")
+        dialog.resize(820, 620)
+        layout = QVBoxLayout(dialog)
+        browser = QTextBrowser(dialog)
+        browser.setOpenExternalLinks(True)
+        browser.setHtml(self._quicklook_gallery_html())
+        layout.addWidget(browser)
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(dialog.reject)
+        layout.addWidget(buttons)
+        exec_dialog = getattr(dialog, "exec", None) or getattr(dialog, "exec_", None)
+        if exec_dialog is not None:
+            exec_dialog()
 
     def ai_context_summary(self):
         """Return a compact text summary of current NASA Earthdata context."""
@@ -3213,7 +3395,7 @@ class EarthdataDockWidget(QDockWidget):
         )
 
     def _set_default_results_column_widths(self):
-        """Set initial Date/Size widths and make ID fill the remaining space."""
+        """Set initial detail widths and make ID fill the remaining space."""
         if self._adjusting_results_columns:
             return
 
@@ -3221,13 +3403,17 @@ class EarthdataDockWidget(QDockWidget):
         try:
             self.results_table.setColumnWidth(1, 90)
             self.results_table.setColumnWidth(2, 80)
+            self.results_table.setColumnWidth(3, 80)
+            self.results_table.setColumnWidth(4, 70)
+            self.results_table.setColumnWidth(5, 80)
+            self.results_table.setColumnWidth(6, 55)
         finally:
             self._adjusting_results_columns = False
 
         self._fit_results_columns_to_width()
 
     def _fit_results_columns_to_width(self):
-        """Make the ID column fill leftover width after Date and Size columns."""
+        """Make the ID column fill leftover width after detail columns."""
         if self._adjusting_results_columns:
             return
 
@@ -3239,9 +3425,12 @@ class EarthdataDockWidget(QDockWidget):
 
         header = self.results_table.horizontalHeader()
         min_width = max(45, header.minimumSectionSize())
-        date_width = max(min_width, self.results_table.columnWidth(1) or 90)
-        size_width = max(min_width, self.results_table.columnWidth(2) or 80)
-        id_width = max(180, viewport_width - date_width - size_width)
+        detail_width = 0
+        for column, fallback in ((1, 90), (2, 80), (3, 80), (4, 70), (5, 80), (6, 55)):
+            detail_width += max(
+                min_width, self.results_table.columnWidth(column) or fallback
+            )
+        id_width = max(180, viewport_width - detail_width)
 
         self._adjusting_results_columns = True
         try:
@@ -3250,9 +3439,28 @@ class EarthdataDockWidget(QDockWidget):
             self._adjusting_results_columns = False
 
     def _on_results_section_resized(self, logical_index, _old_size, _new_size):
-        """Keep ID as the fill column when Date or Size is resized."""
-        if logical_index in (1, 2) and not self._adjusting_results_columns:
+        """Keep ID as the fill column when detail columns are resized."""
+        if logical_index != 0 and not self._adjusting_results_columns:
             QTimer.singleShot(0, self._fit_results_columns_to_width)
+
+    def _filter_result_rows(self):
+        """Hide result rows that do not match the result filter text."""
+        if not hasattr(self, "result_filter_input"):
+            return
+        text = self.result_filter_input.text().strip().lower()
+        for row in range(self.results_table.rowCount()):
+            if not text:
+                self.results_table.setRowHidden(row, False)
+                continue
+            values = []
+            for column in range(self.results_table.columnCount()):
+                item = self.results_table.item(row, column)
+                if item is None:
+                    continue
+                values.append(item.text())
+                values.append(item.toolTip())
+            haystack = " ".join(values).lower()
+            self.results_table.setRowHidden(row, text not in haystack)
 
     def _set_default_download_column_widths(self):
         """Set initial queue column widths and make Granule fill remaining space."""

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -2945,7 +2945,11 @@ class EarthdataDockWidget(QDockWidget):
         if not selected_indices:
             selected_indices = list(range(min(24, len(self._search_results))))
 
-        html_parts = ["<html><body><h3>NASA Earthdata Quicklook Gallery</h3>"]
+        html_parts = [
+            "<html><body>",
+            "<h3>NASA Earthdata Quicklook Gallery</h3>",
+            '<table width="100%" cellspacing="0" cellpadding="8">',
+        ]
         for result_index in selected_indices[:48]:
             if result_index < 0 or result_index >= len(self._search_results):
                 continue
@@ -2954,17 +2958,25 @@ class EarthdataDockWidget(QDockWidget):
             quicklooks = granule_quicklook_links(granule)
             if not quicklooks:
                 continue
-            html_parts.append(
-                '<div style="margin-bottom:14px;">'
-                f"<h4>{html.escape(str(native_id))}</h4>"
-            )
+            image_parts = []
             for url in quicklooks[:6]:
                 image_html = self._quicklook_img_html(url, 180)
                 if image_html:
-                    html_parts.append(image_html)
-            html_parts.append(self._link_list_html(quicklooks, ""))
-            html_parts.append("</div>")
-        html_parts.append("</body></html>")
+                    image_parts.append(image_html)
+            if not image_parts:
+                continue
+            html_parts.append(
+                "<tr>"
+                '<td width="220" valign="top">'
+                f"{''.join(image_parts)}"
+                "</td>"
+                '<td valign="top">'
+                f"<b>{html.escape(str(native_id))}</b>"
+                f"{self._link_list_html(quicklooks, '')}"
+                "</td>"
+                "</tr>"
+            )
+        html_parts.append("</table></body></html>")
         return "".join(html_parts)
 
     def _open_quicklook_gallery(self):

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -2882,13 +2882,19 @@ class EarthdataDockWidget(QDockWidget):
         return f"<ul>{items}</ul>"
 
     def _open_selected_quicklook(self):
-        """Open the first quicklook link for the selected granule."""
-        result_index = self._first_selected_result_index()
-        if result_index < 0 or not self._search_results:
+        """Open the first available quicklook link across selected granules."""
+        if not self._search_results:
             return
-        quicklooks = granule_quicklook_links(self._search_results[result_index])
-        if quicklooks:
-            webbrowser.open(quicklooks[0])
+        selected_indices = self._get_selected_result_indices()
+        if not selected_indices:
+            first_index = self._first_selected_result_index()
+            selected_indices = [first_index] if first_index >= 0 else []
+        for result_index in selected_indices:
+            if 0 <= result_index < len(self._search_results):
+                quicklooks = granule_quicklook_links(self._search_results[result_index])
+                if quicklooks:
+                    webbrowser.open(quicklooks[0])
+                    return
 
     def _quicklook_gallery_html(self):
         """Return an HTML quicklook gallery for selected or current results."""

--- a/nasa_earthdata/dialogs/earthdata_dock.py
+++ b/nasa_earthdata/dialogs/earthdata_dock.py
@@ -3434,7 +3434,6 @@ class EarthdataDockWidget(QDockWidget):
                 return
 
             selected_features = []
-            selected_feature_ids = []
             field_names = [f.name() for f in footprints_layer.fields()]
             has_result_idx_field = "result_idx" in field_names
 
@@ -3449,10 +3448,7 @@ class EarthdataDockWidget(QDockWidget):
 
                 if feature_result_idx in selected_indices:
                     selected_features.append(feature)
-                    selected_feature_ids.append(feature.id())
 
-            if selected_feature_ids:
-                footprints_layer.selectByIds(selected_feature_ids)
             self._add_selected_footprints_overlay(selected_features)
             self.iface.mapCanvas().refresh()
         except RuntimeError as e:
@@ -3548,6 +3544,11 @@ class EarthdataDockWidget(QDockWidget):
                     if feature_result_idx in selected:
                         selected_features.append(feature)
                 self._add_selected_footprints_overlay(selected_features)
+            self._syncing_footprint_table_selection = True
+            try:
+                footprints_layer.removeSelection()
+            finally:
+                self._syncing_footprint_table_selection = False
             self._update_granule_details()
             self._update_quicklook_preview()
         except RuntimeError as e:

--- a/nasa_earthdata/processing/algorithms.py
+++ b/nasa_earthdata/processing/algorithms.py
@@ -724,9 +724,18 @@ class CheckNewGranulesAlgorithm(SearchEarthdataAlgorithm):
 
         with open(baseline_json, "r", encoding="utf-8") as f:
             baseline = json.load(f)
+        if isinstance(baseline, dict):
+            baseline = baseline.get("granules", baseline.get("results"))
+        if baseline is None:
+            baseline = []
+        if not isinstance(baseline, list):
+            raise QgsProcessingException(
+                "Baseline JSON must be a list of granules or contain a "
+                "'granules' list (e.g. earthaccess granules JSON)."
+            )
         baseline_ids = {
             granule_native_id(granule, f"Item {index + 1}")
-            for index, granule in enumerate(baseline or [])
+            for index, granule in enumerate(baseline)
         }
 
         earthaccess = import_earthaccess()

--- a/nasa_earthdata/processing/algorithms.py
+++ b/nasa_earthdata/processing/algorithms.py
@@ -417,6 +417,357 @@ class AddFootprintsAlgorithm(_BaseAlgorithm):
         return {self.OUTPUT: output or source}
 
 
+class ExportStacAlgorithm(_BaseAlgorithm):
+    GRANULES_JSON = "GRANULES_JSON"
+    SHORT_NAME = "SHORT_NAME"
+    CONCEPT_ID = "CONCEPT_ID"
+    OUTPUT = "OUTPUT"
+
+    def name(self):
+        return "export_nasa_earthdata_stac"
+
+    def displayName(self):
+        return self.tr("Export NASA Earthdata STAC")
+
+    def createInstance(self):
+        return ExportStacAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self._add_parameter(
+            QgsProcessingParameterFile(
+                self.GRANULES_JSON,
+                "Granules JSON exported from earthaccess",
+                behavior=QgsProcessingParameterFile.File,
+                extension="json",
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterString(self.SHORT_NAME, "Short name", optional=True)
+        )
+        self._add_parameter(
+            QgsProcessingParameterString(self.CONCEPT_ID, "Concept ID", optional=True)
+        )
+        self._add_parameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                "STAC ItemCollection JSON",
+                fileFilter="JSON files (*.json)",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        import json
+
+        from nasa_earthdata.core.workflows import write_results_stac
+
+        granules_json = self._parameter_as_string(
+            parameters, self.GRANULES_JSON, context
+        )
+        short_name = self._parameter_as_string(parameters, self.SHORT_NAME, context)
+        concept_id = self._parameter_as_string(parameters, self.CONCEPT_ID, context)
+        output = self._parameter_as_file_output(parameters, self.OUTPUT, context)
+        with open(granules_json, "r", encoding="utf-8") as f:
+            granules = json.load(f)
+        write_results_stac(
+            output,
+            granules,
+            {"short_name": short_name, "concept_id": concept_id},
+        )
+        if feedback:
+            feedback.pushInfo(f"Wrote STAC ItemCollection: {output}")
+        return {self.OUTPUT: output}
+
+
+class ExportWorkflowBundleAlgorithm(_BaseAlgorithm):
+    GRANULES_JSON = "GRANULES_JSON"
+    SEARCH_JSON = "SEARCH_JSON"
+    MANIFEST = "MANIFEST"
+    OUTPUT = "OUTPUT"
+
+    def name(self):
+        return "export_nasa_earthdata_workflow_bundle"
+
+    def displayName(self):
+        return self.tr("Export NASA Earthdata Workflow Bundle")
+
+    def createInstance(self):
+        return ExportWorkflowBundleAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self._add_parameter(
+            QgsProcessingParameterFile(
+                self.GRANULES_JSON,
+                "Granules JSON exported from earthaccess",
+                behavior=QgsProcessingParameterFile.File,
+                extension="json",
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterFile(
+                self.SEARCH_JSON,
+                "Optional search preset/workflow JSON",
+                behavior=QgsProcessingParameterFile.File,
+                extension="json",
+                optional=True,
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterString(
+                self.MANIFEST, "Optional download manifest path", optional=True
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                "Workflow bundle JSON",
+                fileFilter="JSON files (*.json)",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        import json
+
+        from nasa_earthdata.core.workflows import (
+            granules_to_export_rows,
+            granules_to_stac_item_collection,
+            write_workflow_bundle,
+        )
+
+        granules_json = self._parameter_as_string(
+            parameters, self.GRANULES_JSON, context
+        )
+        search_json = self._parameter_as_string(parameters, self.SEARCH_JSON, context)
+        manifest = self._parameter_as_string(parameters, self.MANIFEST, context)
+        output = self._parameter_as_file_output(parameters, self.OUTPUT, context)
+        with open(granules_json, "r", encoding="utf-8") as f:
+            granules = json.load(f)
+
+        search = {}
+        if search_json:
+            with open(search_json, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+            search = payload.get("search", payload) if isinstance(payload, dict) else {}
+
+        dataset = search.get("dataset", {}) if isinstance(search, dict) else {}
+        rows = granules_to_export_rows(granules, dataset)
+        stac = granules_to_stac_item_collection(granules, dataset)
+        write_workflow_bundle(
+            output,
+            search,
+            granules,
+            rows,
+            stac_item_collection=stac,
+            manifest=manifest,
+        )
+        if feedback:
+            feedback.pushInfo(f"Wrote workflow bundle: {output}")
+        return {self.OUTPUT: output}
+
+
+class CollectionInfoAlgorithm(_BaseAlgorithm):
+    SHORT_NAME = "SHORT_NAME"
+    CONCEPT_ID = "CONCEPT_ID"
+    OUTPUT = "OUTPUT"
+
+    def name(self):
+        return "nasa_earthdata_collection_info"
+
+    def displayName(self):
+        return self.tr("NASA Earthdata Collection Info")
+
+    def createInstance(self):
+        return CollectionInfoAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self._add_parameter(
+            QgsProcessingParameterString(self.SHORT_NAME, "Short name", optional=True)
+        )
+        self._add_parameter(
+            QgsProcessingParameterString(self.CONCEPT_ID, "Concept ID", optional=True)
+        )
+        self._add_parameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                "Collection metadata summary JSON",
+                fileFilter="JSON files (*.json)",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        import json
+        from pathlib import Path
+
+        from nasa_earthdata.core.net import https_only_urlopen
+        from nasa_earthdata.core.workflows import (
+            cmr_collection_summary,
+            cmr_collection_url,
+        )
+
+        short_name = self._parameter_as_string(parameters, self.SHORT_NAME, context)
+        concept_id = self._parameter_as_string(parameters, self.CONCEPT_ID, context)
+        output = self._parameter_as_file_output(parameters, self.OUTPUT, context)
+        url = cmr_collection_url({"short_name": short_name, "concept_id": concept_id})
+        if not url:
+            raise QgsProcessingException("Short name or concept ID is required")
+        with https_only_urlopen(url, timeout=30) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        summary = cmr_collection_summary(payload)
+        if not summary:
+            raise QgsProcessingException("No CMR collection metadata found")
+        Path(output).parent.mkdir(parents=True, exist_ok=True)
+        with open(output, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2, sort_keys=True)
+        if feedback:
+            feedback.pushInfo(f"Wrote collection metadata summary: {output}")
+        return {self.OUTPUT: output}
+
+
+class CheckNewGranulesAlgorithm(SearchEarthdataAlgorithm):
+    BASELINE_JSON = "BASELINE_JSON"
+    NEW_GRANULES_JSON = "NEW_GRANULES_JSON"
+    NEW_COUNT = "NEW_COUNT"
+
+    def name(self):
+        return "check_new_nasa_earthdata_granules"
+
+    def displayName(self):
+        return self.tr("Check New NASA Earthdata Granules")
+
+    def createInstance(self):
+        return CheckNewGranulesAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        super().initAlgorithm(config)
+        self._add_parameter(
+            QgsProcessingParameterFile(
+                self.BASELINE_JSON,
+                "Baseline granules JSON",
+                behavior=QgsProcessingParameterFile.File,
+                extension="json",
+            )
+        )
+        self._add_parameter(
+            QgsProcessingParameterFileDestination(
+                self.NEW_GRANULES_JSON,
+                "New granules JSON",
+                fileFilter="JSON files (*.json)",
+                optional=True,
+            )
+        )
+        if QgsProcessingOutputNumber is not None:
+            self._add_output(
+                QgsProcessingOutputNumber(self.NEW_COUNT, "Number of new granules")
+            )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        import json
+
+        from nasa_earthdata.core.venv_manager import import_earthaccess
+        from nasa_earthdata.core.workflows import (
+            granule_native_id,
+            granules_to_export_rows,
+            write_granules_json,
+            write_results_geojson,
+        )
+
+        short_name = self._parameter_as_string(parameters, self.SHORT_NAME, context)
+        concept_id = self._parameter_as_string(parameters, self.CONCEPT_ID, context)
+        bbox_text = self._parameter_as_string(parameters, self.BBOX, context)
+        start_date = self._parameter_as_string(parameters, self.START_DATE, context)
+        end_date = self._parameter_as_string(parameters, self.END_DATE, context)
+        max_items = self._parameter_as_int(parameters, self.MAX_ITEMS, context)
+        cloud_min = self._parameter_as_int(parameters, self.CLOUD_MIN, context)
+        cloud_max = self._parameter_as_int(parameters, self.CLOUD_MAX, context)
+        day_night_index = self._parameter_as_int(parameters, self.DAY_NIGHT, context)
+        provider = self._parameter_as_string(parameters, self.PROVIDER, context)
+        version = self._parameter_as_string(parameters, self.VERSION, context)
+        granule_id = self._parameter_as_string(parameters, self.GRANULE_ID, context)
+        orbit_min = self._parameter_as_int(parameters, self.ORBIT_MIN, context)
+        orbit_max = self._parameter_as_int(parameters, self.ORBIT_MAX, context)
+        baseline_json = self._parameter_as_string(
+            parameters, self.BASELINE_JSON, context
+        )
+
+        bbox = None
+        if bbox_text:
+            parts = [float(item.strip()) for item in bbox_text.split(",")]
+            if len(parts) != 4:
+                raise QgsProcessingException("Bounding box must have 4 values")
+            bbox = tuple(parts)
+
+        if not concept_id and not short_name:
+            raise QgsProcessingException("Short name or concept ID is required")
+        kwargs = (
+            {"concept_id": concept_id} if concept_id else {"short_name": short_name}
+        )
+        if bbox is not None:
+            kwargs["bounding_box"] = bbox
+        if start_date and end_date:
+            kwargs["temporal"] = (start_date, end_date)
+        if cloud_min > 0 or cloud_max < 100:
+            kwargs["cloud_cover"] = (cloud_min, cloud_max)
+        day_night = [None, "day", "night", "unspecified"][day_night_index]
+        if day_night is not None:
+            kwargs["day_night_flag"] = day_night
+        if provider:
+            kwargs["provider"] = provider
+        if version:
+            kwargs["version"] = version
+        if granule_id:
+            kwargs["granule_ur"] = granule_id
+        if orbit_min or orbit_max:
+            kwargs["orbit_number"] = (
+                (orbit_min, orbit_max)
+                if orbit_min and orbit_max
+                else orbit_min or orbit_max
+            )
+
+        with open(baseline_json, "r", encoding="utf-8") as f:
+            baseline = json.load(f)
+        baseline_ids = {
+            granule_native_id(granule, f"Item {index + 1}")
+            for index, granule in enumerate(baseline or [])
+        }
+
+        earthaccess = import_earthaccess()
+        granules = earthaccess.search_data(count=max_items, **kwargs)
+        output = self._parameter_as_file_output(parameters, self.OUTPUT, context)
+        if output:
+            rows = granules_to_export_rows(
+                granules,
+                {"short_name": short_name, "concept_id": concept_id},
+            )
+            write_results_geojson(output, rows, None)
+        output_all_json = self._parameter_as_file_output(
+            parameters, self.OUTPUT_JSON, context
+        )
+        if output_all_json:
+            write_granules_json(output_all_json, granules)
+
+        new_granules = []
+        for index, granule in enumerate(granules or []):
+            native_id = granule_native_id(granule, f"Item {index + 1}")
+            if native_id not in baseline_ids:
+                new_granules.append(granule)
+
+        output_json = self._parameter_as_file_output(
+            parameters, self.NEW_GRANULES_JSON, context
+        )
+        if output_json:
+            write_granules_json(output_json, new_granules)
+        if feedback:
+            feedback.pushInfo(
+                f"Found {len(new_granules)} new granule(s) out of {len(granules or [])}"
+            )
+        return {
+            self.OUTPUT: output,
+            self.OUTPUT_JSON: output_all_json,
+            self.NEW_GRANULES_JSON: output_json,
+            self.NEW_COUNT: len(new_granules),
+            self.COUNT: len(granules or []),
+        }
+
+
 class CreateRgbCogLayerAlgorithm(_BaseAlgorithm):
     RED = "RED"
     GREEN = "GREEN"

--- a/nasa_earthdata/processing/provider.py
+++ b/nasa_earthdata/processing/provider.py
@@ -12,9 +12,13 @@ if not isinstance(QgsProcessingProvider, type):
 
 from .algorithms import (
     AddFootprintsAlgorithm,
+    CheckNewGranulesAlgorithm,
+    CollectionInfoAlgorithm,
     CreateNormalizedDifferenceVrtAlgorithm,
     CreateRgbCogLayerAlgorithm,
     DownloadGranulesAlgorithm,
+    ExportStacAlgorithm,
+    ExportWorkflowBundleAlgorithm,
     SearchEarthdataAlgorithm,
 )
 
@@ -43,6 +47,10 @@ class NASAEarthdataProcessingProvider(QgsProcessingProvider):
             SearchEarthdataAlgorithm(),
             DownloadGranulesAlgorithm(),
             AddFootprintsAlgorithm(),
+            ExportStacAlgorithm(),
+            ExportWorkflowBundleAlgorithm(),
+            CollectionInfoAlgorithm(),
+            CheckNewGranulesAlgorithm(),
             CreateRgbCogLayerAlgorithm(),
             CreateNormalizedDifferenceVrtAlgorithm(),
         ):

--- a/tests/test_earthdata_dock_core.py
+++ b/tests/test_earthdata_dock_core.py
@@ -184,6 +184,21 @@ def test_index_layer_visual_range_sets_normalized_bounds():
     assert layer.fake_renderer.maximum == 1.0
 
 
+def test_deleted_qgis_layer_wrapper_is_cleared():
+    class DeletedLayer:
+        def isValid(self):
+            raise RuntimeError(
+                "wrapped C/C++ object of type QgsVectorLayer has been deleted"
+            )
+
+    dock = type("Dock", (), {"_footprints_layer": DeletedLayer()})()
+
+    layer = EarthdataDockWidget._valid_layer_or_none(dock, "_footprints_layer")
+
+    assert layer is None
+    assert dock._footprints_layer is None
+
+
 def test_compact_result_id_preserves_start_and_end():
     result_id = "OPERA_L3_DSWx-HLS_T10SEG_20250510T184540Z_20250512T010101Z_L8_30_v1.0"
 

--- a/tests/test_processing_provider.py
+++ b/tests/test_processing_provider.py
@@ -1,5 +1,9 @@
 from nasa_earthdata.processing.algorithms import (
+    CheckNewGranulesAlgorithm,
+    CollectionInfoAlgorithm,
     CreateNormalizedDifferenceVrtAlgorithm,
+    ExportStacAlgorithm,
+    ExportWorkflowBundleAlgorithm,
     SearchEarthdataAlgorithm,
 )
 
@@ -16,3 +20,13 @@ def test_normalized_difference_algorithm_identity():
 
     assert algorithm.name() == "create_normalized_difference_vrt"
     assert algorithm.displayName() == "Create Normalized Difference VRT"
+
+
+def test_new_processing_algorithm_identities():
+    assert ExportStacAlgorithm().name() == "export_nasa_earthdata_stac"
+    assert (
+        ExportWorkflowBundleAlgorithm().name()
+        == "export_nasa_earthdata_workflow_bundle"
+    )
+    assert CollectionInfoAlgorithm().name() == "nasa_earthdata_collection_info"
+    assert CheckNewGranulesAlgorithm().name() == "check_new_nasa_earthdata_granules"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -10,6 +10,7 @@ from nasa_earthdata.core.workflows import (
     download_queue_state_path,
     granule_export_row,
     granule_quicklook_links,
+    granule_inaccessible_quicklook_links,
     likely_existing_download_files,
     load_download_queue_state,
     load_search_presets,
@@ -51,6 +52,11 @@ class FakeGranule(dict):
                     "RelatedUrls": [
                         {
                             "URL": "https://example.test/preview.jpg",
+                            "Type": "GET RELATED VISUALIZATION",
+                            "Subtype": "BROWSE",
+                        },
+                        {
+                            "URL": "s3://example-bucket/preview.jpg",
                             "Type": "GET RELATED VISUALIZATION",
                             "Subtype": "BROWSE",
                         },
@@ -240,6 +246,9 @@ def test_granules_json_stac_and_workflow_bundle_exports(tmp_path):
 def test_quicklook_and_cmr_collection_helpers():
     granule = FakeGranule(["https://example.test/HLS.B04.tif"])
     assert granule_quicklook_links(granule) == ["https://example.test/preview.jpg"]
+    assert granule_inaccessible_quicklook_links(granule) == [
+        "s3://example-bucket/preview.jpg"
+    ]
     assert (
         cmr_collection_url({"concept_id": "C2021957657-LPCLOUD"})
         == "https://cmr.earthdata.nasa.gov/search/collections.json?concept_id=C2021957657-LPCLOUD"


### PR DESCRIPTION
## Summary
- Expand the result table with Provider, Cloud, Day/Night, and COG columns and add an inline filter input, a "Use Layer AOI" button, and a scrollable quicklook gallery dialog for selected granules.
- Register four new Processing algorithms (Export STAC, Export Workflow Bundle, Collection Info, Check New Granules) so saved-search workflows are reproducible from the Processing Toolbox and Model Designer.
- Update the README to document the new gallery, filtering, layer AOI shortcut, and Processing tools.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/test_processing_provider.py`
- [ ] Load the plugin in QGIS, run a search, and verify the new result columns, filter input, "Use Layer AOI" button, and quicklook gallery work as expected.
- [ ] Run each new Processing algorithm (Export STAC, Export Workflow Bundle, Collection Info, Check New Granules) from the Processing Toolbox against a sample granules JSON.