### PR TITLE
fix: theme-aware status labels and clean toolbar/menu reload

### DIFF
--- a/nasa_earthdata/dialogs/settings_dock.py
+++ b/nasa_earthdata/dialogs/settings_dock.py
@@ -27,7 +27,7 @@ from qgis.PyQt.QtWidgets import (
     QTabWidget,
     QProgressBar,
 )
-from qgis.PyQt.QtGui import QFont
+from qgis.PyQt.QtGui import QFont, QPalette
 
 
 class SettingsDockWidget(QDockWidget):
@@ -57,6 +57,33 @@ class SettingsDockWidget(QDockWidget):
 
         self._setup_ui()
         self._load_settings()
+
+    def _uses_dark_palette(self):
+        """Return whether the active Qt palette is dark."""
+        window_role = getattr(QPalette, "ColorRole", QPalette).Window
+        color = self.palette().color(window_role)
+        luminance = (
+            0.2126 * color.red() + 0.7152 * color.green() + 0.0722 * color.blue()
+        )
+        return luminance < 128
+
+    def _text_style(self, tone="text", font_size=None, bold=False):
+        """Build readable label styles for both light and dark QGIS themes."""
+        dark = self._uses_dark_palette()
+        colors = {
+            "text": "#f0f3f5" if dark else "#202124",
+            "muted": "#d0d7de" if dark else "#5f6368",
+            "success": "#7ee2a8" if dark else "#1b5e20",
+            "warning": "#ffd166" if dark else "#8a5a00",
+            "error": "#ff8a80" if dark else "#b00020",
+            "info": "#9cc9ff" if dark else "#0b57d0",
+        }
+        declarations = [f"color: {colors.get(tone, colors['text'])};"]
+        if font_size is not None:
+            declarations.append(f"font-size: {font_size}px;")
+        if bold:
+            declarations.append("font-weight: bold;")
+        return " ".join(declarations)
 
     def _setup_ui(self):
         """Set up the settings UI."""
@@ -134,7 +161,7 @@ class SettingsDockWidget(QDockWidget):
             "Register at: https://urs.earthdata.nasa.gov/"
         )
         info_label.setWordWrap(True)
-        info_label.setStyleSheet("color: #666; font-size: 10px;")
+        info_label.setStyleSheet(self._text_style("muted", font_size=10))
         creds_layout.addRow(info_label)
 
         # Username
@@ -169,7 +196,7 @@ class SettingsDockWidget(QDockWidget):
             "The file should be located at: ~/.netrc"
         )
         netrc_info.setWordWrap(True)
-        netrc_info.setStyleSheet("color: #666; font-size: 10px;")
+        netrc_info.setStyleSheet(self._text_style("muted", font_size=10))
         netrc_layout.addRow(netrc_info)
 
         # Check netrc
@@ -491,11 +518,11 @@ class SettingsDockWidget(QDockWidget):
 
         if not username or not password:
             self.creds_status_label.setText("Please enter username and password")
-            self.creds_status_label.setStyleSheet("color: orange;")
+            self.creds_status_label.setStyleSheet(self._text_style("warning"))
             return
 
         self.creds_status_label.setText("Testing credentials...")
-        self.creds_status_label.setStyleSheet("color: blue;")
+        self.creds_status_label.setStyleSheet(self._text_style("info"))
 
         try:
             from ..core.venv_manager import import_earthaccess
@@ -514,20 +541,20 @@ class SettingsDockWidget(QDockWidget):
                 self._save_netrc(username, password)
                 self.creds_status_label.setText("✓ Credentials valid! Saved to .netrc")
                 self.creds_status_label.setStyleSheet(
-                    "color: green; font-weight: bold;"
+                    self._text_style("success", bold=True)
                 )
                 # Update netrc status
                 self._check_netrc()
             else:
                 self.creds_status_label.setText("✗ Authentication failed")
-                self.creds_status_label.setStyleSheet("color: red;")
+                self.creds_status_label.setStyleSheet(self._text_style("error"))
 
         except ImportError as e:
             self.creds_status_label.setText(str(e)[:200])
-            self.creds_status_label.setStyleSheet("color: red;")
+            self.creds_status_label.setStyleSheet(self._text_style("error"))
         except Exception as e:
             self.creds_status_label.setText(f"Error: {str(e)[:50]}")
-            self.creds_status_label.setStyleSheet("color: red;")
+            self.creds_status_label.setStyleSheet(self._text_style("error"))
 
     def _save_netrc(self, username, password):
         """Save NASA Earthdata credentials to .netrc file."""
@@ -586,7 +613,7 @@ class SettingsDockWidget(QDockWidget):
 
         if not netrc_path.exists():
             self.netrc_status_label.setText("✗ .netrc file not found")
-            self.netrc_status_label.setStyleSheet("color: orange;")
+            self.netrc_status_label.setStyleSheet(self._text_style("warning"))
             return
 
         try:
@@ -601,15 +628,15 @@ class SettingsDockWidget(QDockWidget):
                     f"✓ Found Earthdata credentials for: {username}"
                 )
                 self.netrc_status_label.setStyleSheet(
-                    "color: green; font-weight: bold;"
+                    self._text_style("success", bold=True)
                 )
             else:
                 self.netrc_status_label.setText("✗ No Earthdata credentials in .netrc")
-                self.netrc_status_label.setStyleSheet("color: orange;")
+                self.netrc_status_label.setStyleSheet(self._text_style("warning"))
 
         except Exception as e:
             self.netrc_status_label.setText(f"Error reading .netrc: {str(e)[:30]}")
-            self.netrc_status_label.setStyleSheet("color: red;")
+            self.netrc_status_label.setStyleSheet(self._text_style("error"))
 
     def _get_netrc_earthdata_credentials(self):
         """Return Earthdata credentials from ~/.netrc if available."""
@@ -700,12 +727,12 @@ class SettingsDockWidget(QDockWidget):
             self.creds_status_label.setText(
                 "Using credentials from ~/.netrc (preferred)"
             )
-            self.creds_status_label.setStyleSheet("color: green;")
+            self.creds_status_label.setStyleSheet(self._text_style("success"))
         elif source == "environment":
             self.creds_status_label.setText(
                 "Using credentials from EARTHDATA_USERNAME/EARTHDATA_PASSWORD"
             )
-            self.creds_status_label.setStyleSheet("color: green;")
+            self.creds_status_label.setStyleSheet(self._text_style("success"))
 
         # General
         self.download_dir_input.setText(
@@ -767,16 +794,16 @@ class SettingsDockWidget(QDockWidget):
                     "✓ Credentials saved to ~/.netrc and environment"
                 )
                 self.creds_status_label.setStyleSheet(
-                    "color: green; font-weight: bold;"
+                    self._text_style("success", bold=True)
                 )
             except Exception as e:
                 self.creds_status_label.setText(f"Failed to save .netrc: {str(e)[:50]}")
-                self.creds_status_label.setStyleSheet("color: red;")
+                self.creds_status_label.setStyleSheet(self._text_style("error"))
         elif username:
             self.creds_status_label.setText(
                 "Username saved. Enter password and Save to persist to ~/.netrc"
             )
-            self.creds_status_label.setStyleSheet("color: orange;")
+            self.creds_status_label.setStyleSheet(self._text_style("warning"))
 
         # General
         self.settings.setValue(

--- a/nasa_earthdata/nasa_earthdata.py
+++ b/nasa_earthdata/nasa_earthdata.py
@@ -13,6 +13,8 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMenu, QToolBar, QMessageBox
 
 OPEN_GEOAGENT_PLUGIN_CANDIDATES = ("open_geoagent",)
+TOOLBAR_OBJECT_NAME = "NASAEarthdataToolbar"
+MENU_TITLE = "&NASA Earthdata"
 
 
 class NASAEarthdata:
@@ -89,13 +91,16 @@ class NASAEarthdata:
 
     def initGui(self):
         """Create the menu entries and toolbar icons inside the QGIS GUI."""
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
+
         # Create menu
-        self.menu = QMenu("&NASA Earthdata")
+        self.menu = QMenu(MENU_TITLE)
         self.iface.mainWindow().menuBar().addMenu(self.menu)
 
         # Create toolbar
         self.toolbar = QToolBar("NASA Earthdata Toolbar")
-        self.toolbar.setObjectName("NASAEarthdataToolbar")
+        self.toolbar.setObjectName(TOOLBAR_OBJECT_NAME)
         self.iface.addToolBar(self.toolbar)
 
         # Get icon paths
@@ -175,6 +180,80 @@ class NASAEarthdata:
 
         self._register_processing_provider()
 
+    def _remove_toolbar(self, toolbar):
+        """Detach and schedule deletion of a plugin toolbar widget."""
+        if toolbar is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        actions = []
+        try:
+            actions = list(toolbar.actions())
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.clear()
+        except Exception:
+            pass  # nosec B110
+        for action in actions:
+            try:
+                action.deleteLater()
+            except Exception:
+                pass  # nosec B110
+        try:
+            main_window.removeToolBar(toolbar)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.hide()
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_toolbars_by_object_name(self):
+        """Remove current or stale NASA Earthdata toolbars from QGIS."""
+        main_window = self.iface.mainWindow()
+        for toolbar in main_window.findChildren(QToolBar, TOOLBAR_OBJECT_NAME):
+            self._remove_toolbar(toolbar)
+
+    def _remove_menu(self, menu):
+        """Detach and schedule deletion of a plugin menu."""
+        if menu is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        try:
+            menu.clear()
+        except Exception:
+            pass  # nosec B110
+        try:
+            main_window.menuBar().removeAction(menu.menuAction())
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_menus_by_title(self):
+        """Remove current or stale NASA Earthdata menus from QGIS."""
+        menu_bar = self.iface.mainWindow().menuBar()
+        for action in menu_bar.actions():
+            menu = action.menu()
+            if menu is not None and menu.title() == MENU_TITLE:
+                self._remove_menu(menu)
+
     def unload(self):
         """Remove the plugin menu item and icon from QGIS GUI."""
         # Remove dock widgets
@@ -188,19 +267,28 @@ class NASAEarthdata:
             self._settings_dock.deleteLater()
             self._settings_dock = None
 
-        # Remove actions from menu
+        # Remove actions from plugin UI containers.
         for action in self.actions:
-            self.iface.removePluginMenu("&NASA Earthdata", action)
+            if self.toolbar:
+                self.toolbar.removeAction(action)
+            if self.menu:
+                self.menu.removeAction(action)
+            action.deleteLater()
+        self.actions = []
 
         # Remove toolbar
         if self.toolbar:
-            del self.toolbar
+            self._remove_toolbar(self.toolbar)
+            self.toolbar = None
+        self._remove_toolbars_by_object_name()
 
         self._unregister_processing_provider()
 
         # Remove menu
         if self.menu:
-            self.menu.deleteLater()
+            self._remove_menu(self.menu)
+            self.menu = None
+        self._remove_menus_by_title()
         try:
             if getattr(self.iface, "_nasa_earthdata_plugin", None) is self:
                 delattr(self.iface, "_nasa_earthdata_plugin")


### PR DESCRIPTION
## Summary
- Read status label colors from the active Qt palette so the Settings dock stays legible on dark QGIS themes
- Remove stale NASA Earthdata toolbars and menus by object name and title on init/unload, preventing duplicate UI after plugin reload

## Test plan
- [ ] Open the Settings dock on a light theme and confirm status text reads as before
- [ ] Switch QGIS to a dark theme and confirm credential/netrc status messages remain readable
- [ ] Reload the plugin from the Plugin Manager and confirm no duplicate NASA Earthdata toolbar or menu appears