### PR TITLE
[codex] Fix QGIS plugin reload cleanup

### DIFF
--- a/nasa_earthdata/nasa_earthdata.py
+++ b/nasa_earthdata/nasa_earthdata.py
@@ -18,6 +18,7 @@ OPEN_GEOAGENT_PLUGIN_CANDIDATES = ("open_geoagent",)
 TOOLBAR_OBJECT_NAME = "NASAEarthdataToolbar"
 MENU_TITLE = "&NASA Earthdata"
 
+
 class NASAEarthdata:
     """NASA Earthdata Plugin implementation class for QGIS."""
 
@@ -179,7 +180,6 @@ class NASAEarthdata:
         )
 
         self._register_processing_provider()
-
 
     def _remove_toolbar(self, toolbar):
         """Detach and schedule deletion of a plugin toolbar widget."""

--- a/nasa_earthdata/nasa_earthdata.py
+++ b/nasa_earthdata/nasa_earthdata.py
@@ -15,6 +15,9 @@ from qgis.PyQt.QtWidgets import QAction, QMenu, QToolBar, QMessageBox
 OPEN_GEOAGENT_PLUGIN_CANDIDATES = ("open_geoagent",)
 
 
+TOOLBAR_OBJECT_NAME = "NASAEarthdataToolbar"
+MENU_TITLE = "&NASA Earthdata"
+
 class NASAEarthdata:
     """NASA Earthdata Plugin implementation class for QGIS."""
 
@@ -89,13 +92,15 @@ class NASAEarthdata:
 
     def initGui(self):
         """Create the menu entries and toolbar icons inside the QGIS GUI."""
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
         # Create menu
         self.menu = QMenu("&NASA Earthdata")
         self.iface.mainWindow().menuBar().addMenu(self.menu)
 
         # Create toolbar
         self.toolbar = QToolBar("NASA Earthdata Toolbar")
-        self.toolbar.setObjectName("NASAEarthdataToolbar")
+        self.toolbar.setObjectName(TOOLBAR_OBJECT_NAME)
         self.iface.addToolBar(self.toolbar)
 
         # Get icon paths
@@ -175,6 +180,93 @@ class NASAEarthdata:
 
         self._register_processing_provider()
 
+
+    def _remove_toolbar(self, toolbar):
+        """Detach and schedule deletion of a plugin toolbar widget."""
+        if toolbar is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        actions = []
+        try:
+            actions = list(toolbar.actions())
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.clear()
+        except Exception:
+            pass  # nosec B110
+        for action in actions:
+            try:
+                action.deleteLater()
+            except Exception:
+                pass  # nosec B110
+        try:
+            main_window.removeToolBar(toolbar)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.hide()
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_toolbars_by_object_name(self):
+        """Remove current or stale plugin toolbars from QGIS."""
+        main_window = self.iface.mainWindow()
+        for toolbar in main_window.findChildren(QToolBar, TOOLBAR_OBJECT_NAME):
+            self._remove_toolbar(toolbar)
+
+    def _plugin_menu_titles(self):
+        """Return possible translated and untranslated plugin menu titles."""
+        titles = {MENU_TITLE}
+        translator = getattr(self, "tr", None)
+        if callable(translator):
+            try:
+                titles.add(translator(MENU_TITLE))
+            except Exception:
+                pass  # nosec B110
+        return titles
+
+    def _remove_menu(self, menu):
+        """Detach and schedule deletion of a plugin menu."""
+        if menu is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        try:
+            menu.clear()
+        except Exception:
+            pass  # nosec B110
+        try:
+            main_window.menuBar().removeAction(menu.menuAction())
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_menus_by_title(self):
+        """Remove current or stale plugin menus from QGIS."""
+        menu_bar = self.iface.mainWindow().menuBar()
+        titles = self._plugin_menu_titles()
+        for action in menu_bar.actions():
+            menu = action.menu()
+            if menu is not None and menu.title() in titles:
+                self._remove_menu(menu)
+
     def unload(self):
         """Remove the plugin menu item and icon from QGIS GUI."""
         # Remove dock widgets
@@ -206,6 +298,9 @@ class NASAEarthdata:
                 delattr(self.iface, "_nasa_earthdata_plugin")
         except Exception:
             pass  # nosec B110
+
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
 
     def _register_processing_provider(self):
         """Register QGIS Processing provider when Processing is available."""


### PR DESCRIPTION
## Summary

Fix QGIS Plugin Reloader warnings caused by custom plugin toolbars and menus that can remain attached to the QGIS main window after `unload()`.

## Changes

- Remove stale plugin toolbars by object name before creating a new toolbar.
- Detach and schedule stale toolbars for deletion during unload.
- Remove stale plugin menus by title before initialization and during unload.
- Keep cleanup best-effort so reload/unload can continue even if QGIS has already detached a widget.

## Validation

- Ran `python -m py_compile` on the changed plugin entry-point file.
- Ran `git diff --check`.
